### PR TITLE
Add zone-based firewall prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Single Docker container. No external dependencies. Zero data collection.
 
 - **Docker** and **Docker Compose**
 - **UniFi Router** (or any UniFi gateway that supports remote syslog)
+- **Zone-based firewall** (not legacy/classic). The Firewall Syslog Manager and firewall policy API require the zone-based policy engine. If you are still on the legacy/classic firewall, migrate via **Settings > Policy Engine** in your UniFi controller before setting up ULI.
 - **MaxMind GeoLite2 account** ([free signup](https://www.maxmind.com/en/geolite2/signup)) - for GeoIP/ASN lookups
 - **AbuseIPDB API key** ([free tier](https://www.abuseipdb.com/register?plan=free), optional) - for threat scoring
 


### PR DESCRIPTION
Users on the legacy/classic firewall will see "No firewall policies
found" in ULI because the Integration API only returns zone-based
policies. This adds a clear prerequisite so users know to migrate
before setting up ULI.

Closes #61 (partially)

https://claude.ai/code/session_01SAQrA8Cck5Q3bWTMhxug9k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites section to clarify Zone-based firewall requirements before setup.
  * Added migration guidance for users with legacy firewall configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->