### PR TITLE
fix(vacuum): tune autovacuum on logs table and harden post-cleanup VACUUM

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -116,8 +116,17 @@ CREATE INDEX IF NOT EXISTS idx_logs_nondns_timestamp
 ALTER TABLE logs SET (
     autovacuum_vacuum_scale_factor  = 0.01,
     autovacuum_vacuum_cost_delay    = 2,
-    autovacuum_analyze_scale_factor = 0.02
+    autovacuum_analyze_scale_factor = 0.02,
+    -- Higher I/O budget per autovacuum worker: lets it process more pages per
+    -- delay cycle and keep pace with high-ingestion dead-tuple accumulation.
+    autovacuum_vacuum_cost_limit    = 10000
 );
+
+-- Log every autovacuum operation on this database for production observability.
+-- Lets operators verify the scale_factor tuning is firing as expected after
+-- large cleanups.  Set log_autovacuum_min_duration = 60000 to restrict logging
+-- to operations taking > 60 s if the default produces too much volume.
+ALTER DATABASE "unifi_logs" SET log_autovacuum_min_duration = '0';
 
 -- AbuseIPDB threat score cache (persistent across restarts)
 CREATE TABLE IF NOT EXISTS ip_threats (

--- a/init.sql
+++ b/init.sql
@@ -122,15 +122,15 @@ ALTER TABLE logs SET (
     autovacuum_vacuum_cost_limit    = 10000
 );
 
--- Log every autovacuum operation on this database for production observability.
--- Lets operators verify the scale_factor tuning is firing as expected after
--- large cleanups.  Set log_autovacuum_min_duration = 60000 to restrict logging
--- to operations taking > 60 s if the default produces too much volume.
+-- Log autovacuum operations that take longer than 60 s on this database.
+-- This lets operators verify the scale_factor tuning is firing as expected
+-- after large cleanups without flooding logs on busy systems.
+-- Lower to '0' to log every autovacuum/autoanalyze for deeper debugging.
 DO $$
 BEGIN
     -- Use current_database() so this script is portable across any DB name.
     EXECUTE format(
-        'ALTER DATABASE %I SET log_autovacuum_min_duration = ''0''',
+        'ALTER DATABASE %I SET log_autovacuum_min_duration = ''60000''',
         current_database()
     );
 END $$;

--- a/init.sql
+++ b/init.sql
@@ -109,6 +109,16 @@ CREATE INDEX IF NOT EXISTS idx_logs_nondns_timestamp
     ON logs (timestamp DESC)
     WHERE log_type != 'dns';
 
+-- Aggressive autovacuum for the high-churn logs table.
+-- Default scale_factor=0.2 means autovacuum waits until 20% of rows are dead
+-- before reclaiming space. On a large table that threshold is never reached
+-- quickly enough after batch deletes, causing unbounded bloat (issue #92).
+ALTER TABLE logs SET (
+    autovacuum_vacuum_scale_factor  = 0.01,
+    autovacuum_vacuum_cost_delay    = 2,
+    autovacuum_analyze_scale_factor = 0.02
+);
+
 -- AbuseIPDB threat score cache (persistent across restarts)
 CREATE TABLE IF NOT EXISTS ip_threats (
     ip              INET PRIMARY KEY,

--- a/init.sql
+++ b/init.sql
@@ -126,7 +126,14 @@ ALTER TABLE logs SET (
 -- Lets operators verify the scale_factor tuning is firing as expected after
 -- large cleanups.  Set log_autovacuum_min_duration = 60000 to restrict logging
 -- to operations taking > 60 s if the default produces too much volume.
-ALTER DATABASE "unifi_logs" SET log_autovacuum_min_duration = '0';
+DO $$
+BEGIN
+    -- Use current_database() so this script is portable across any DB name.
+    EXECUTE format(
+        'ALTER DATABASE %I SET log_autovacuum_min_duration = ''0''',
+        current_database()
+    );
+END $$;
 
 -- AbuseIPDB threat score cache (persistent across restarts)
 CREATE TABLE IF NOT EXISTS ip_threats (

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -260,6 +260,7 @@ class Database:
     ]
 
     def __init__(self, conn_params: dict | None = None, min_conn: int = 2, max_conn: int = 10):
+        """Configure connection parameters and pool size limits."""
         self.conn_params = conn_params or build_conn_params()
         self.pool = None
         self.min_conn = min_conn

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -18,7 +18,6 @@ import psycopg2
 import psycopg2.errors
 from psycopg2 import pool, extras
 from psycopg2.extras import Json
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 logger = logging.getLogger(__name__)
 
@@ -1244,13 +1243,18 @@ END $$;""",
         if result['deleted_so_far'] > 0:
             # Run VACUUM ANALYZE after bulk deletes so dead tuples are reclaimed
             # immediately, not left for autovacuum to find on its next cycle.
-            # VACUUM cannot run inside a transaction — requires autocommit.
+            # VACUUM cannot run inside a transaction — use a dedicated ephemeral
+            # connection (never returned to the pool) so autocommit mode cannot
+            # leak back to other callers.
             try:
-                with self.get_conn() as conn:
-                    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-                    with conn.cursor() as cur:
+                vac_conn = psycopg2.connect(**self.conn_params)
+                try:
+                    vac_conn.autocommit = True
+                    with vac_conn.cursor() as cur:
                         cur.execute("VACUUM ANALYZE logs")
-                logger.info("Post-cleanup VACUUM ANALYZE complete")
+                    logger.info("Post-cleanup VACUUM ANALYZE complete")
+                finally:
+                    vac_conn.close()
             except Exception as exc:
                 logger.warning("Post-cleanup VACUUM ANALYZE failed (non-fatal): %s", exc)
         return result

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -1067,6 +1067,10 @@ END $$;""",
     VACUUM_TIMEOUT_SECS = 300
     # Number of times to retry a transient VACUUM failure before giving up.
     # Does not retry on query-cancelled (timeout) — those are intentional aborts.
+    # In pathological cases (table too large to vacuum within VACUUM_TIMEOUT_SECS)
+    # the tuned autovacuum scale_factor in init.sql handles dead-tuple reclaim.
+    # Monitor pg_stat_user_tables.n_dead_tup post-deploy to verify autovacuum
+    # is keeping up when explicit VACUUM is skipped.
     VACUUM_MAX_RETRIES = 2
 
     @staticmethod
@@ -1288,7 +1292,8 @@ END $$;""",
                 with vac_conn.cursor() as cur:
                     # Enforce a hard timeout so a blocked VACUUM cannot stall
                     # the next cleanup cycle or hold a connection indefinitely.
-                    cur.execute(f"SET statement_timeout = '{self.VACUUM_TIMEOUT_SECS}s'")
+                    cur.execute("SET statement_timeout = %s",
+                                [f"{self.VACUUM_TIMEOUT_SECS}s"])
                     cur.execute("VACUUM ANALYZE logs")
                 logger.info("Post-cleanup VACUUM ANALYZE complete (attempt %d/%d)",
                             attempt, self.VACUUM_MAX_RETRIES)
@@ -1302,7 +1307,7 @@ END $$;""",
                     self.VACUUM_TIMEOUT_SECS, attempt,
                 )
                 return
-            except Exception as exc:
+            except psycopg2.Error as exc:
                 logger.warning(
                     "Post-cleanup VACUUM ANALYZE failed on attempt %d/%d: %s",
                     attempt, self.VACUUM_MAX_RETRIES, exc,
@@ -1319,8 +1324,8 @@ END $$;""",
                 if vac_conn:
                     try:
                         vac_conn.close()
-                    except Exception:
-                        pass  # ignore close errors
+                    except psycopg2.Error as close_exc:
+                        logger.debug("Error closing VACUUM connection: %s", close_exc)
 
     def get_stats(self) -> dict:
         """Get basic stats for health check / logging."""

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -18,6 +18,7 @@ import psycopg2
 import psycopg2.errors
 from psycopg2 import pool, extras
 from psycopg2.extras import Json
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 logger = logging.getLogger(__name__)
 
@@ -1239,6 +1240,18 @@ END $$;""",
                     "general_retention=%d days, dns_retention=%d days)",
                     result['deleted_so_far'], result['dns_deleted'],
                     result['non_dns_deleted'], general_days, dns_days)
+        if result['deleted_so_far'] > 0:
+            # Run VACUUM ANALYZE after bulk deletes so dead tuples are reclaimed
+            # immediately, not left for autovacuum to find on its next cycle.
+            # VACUUM cannot run inside a transaction — requires autocommit.
+            try:
+                with self.get_conn() as conn:
+                    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+                    with conn.cursor() as cur:
+                        cur.execute("VACUUM ANALYZE logs")
+                logger.info("Post-cleanup VACUUM ANALYZE complete")
+            except Exception as exc:
+                logger.warning("Post-cleanup VACUUM ANALYZE failed (non-fatal): %s", exc)
         return result
 
     def get_stats(self) -> dict:

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -680,6 +680,18 @@ END $$;""",
             )""",
             """CREATE INDEX IF NOT EXISTS idx_rdns_cache_looked_up_at
                 ON rdns_cache (looked_up_at)""",
+            # ── Autovacuum tuning for the high-churn logs table ──────────
+            # Default scale_factor=0.2 triggers autovacuum only after 20 % of
+            # rows are dead — on a 33 M-row table that is 6.6 M dead tuples.
+            # Lower thresholds ensure autovacuum fires promptly after batch
+            # retention deletes. ALTER TABLE logs SET is idempotent: safe to
+            # re-apply on every boot (no IF NOT EXISTS equivalent needed).
+            """ALTER TABLE logs SET (
+                autovacuum_vacuum_scale_factor  = 0.01,
+                autovacuum_vacuum_cost_delay    = 2,
+                autovacuum_analyze_scale_factor = 0.02,
+                autovacuum_vacuum_cost_limit    = 10000
+            )""",
         ]
         try:
             with self.get_conn() as conn:

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -1059,7 +1059,15 @@ END $$;""",
     # Only run an explicit VACUUM ANALYZE after cleanup when the number of
     # deleted rows is above this threshold.  Trivial runs (a handful of rows)
     # are handled by tuned autovacuum, avoiding the cost of a full-table scan.
-    VACUUM_MIN_DELETED = 1_000
+    # Set equal to RETENTION_BATCH_SIZE so VACUUM only fires after at least one
+    # full batch — sub-batch deletions are cheap enough for autovacuum alone.
+    VACUUM_MIN_DELETED = 5_000
+    # Abort explicit VACUUM ANALYZE if it exceeds this duration.  A stuck VACUUM
+    # should not block the next cleanup cycle or hold a connection indefinitely.
+    VACUUM_TIMEOUT_SECS = 300
+    # Number of times to retry a transient VACUUM failure before giving up.
+    # Does not retry on query-cancelled (timeout) — those are intentional aborts.
+    VACUUM_MAX_RETRIES = 2
 
     @staticmethod
     def validate_retention_days(general_days: int, dns_days: int):
@@ -1252,17 +1260,7 @@ END $$;""",
             # connection (never returned to the pool) so autocommit mode cannot
             # leak back to other callers.
             if result['deleted_so_far'] >= self.VACUUM_MIN_DELETED:
-                try:
-                    vac_conn = psycopg2.connect(**self.conn_params)
-                    try:
-                        vac_conn.autocommit = True
-                        with vac_conn.cursor() as cur:
-                            cur.execute("VACUUM ANALYZE logs")
-                        logger.info("Post-cleanup VACUUM ANALYZE complete")
-                    finally:
-                        vac_conn.close()
-                except Exception as exc:
-                    logger.warning("Post-cleanup VACUUM ANALYZE failed (non-fatal): %s", exc)
+                self._run_explicit_vacuum()
             else:
                 logger.debug(
                     "Post-cleanup VACUUM skipped (deleted=%d < threshold=%d); "
@@ -1270,6 +1268,59 @@ END $$;""",
                     result['deleted_so_far'], self.VACUUM_MIN_DELETED,
                 )
         return result
+
+    def _run_explicit_vacuum(self) -> None:
+        """Run VACUUM ANALYZE on the logs table with timeout and retry logic.
+
+        Uses a dedicated ephemeral connection in autocommit mode because
+        VACUUM cannot run inside a transaction.  The connection is never
+        returned to the pool so autocommit cannot leak to other callers.
+
+        Non-fatal: failures are logged as warnings; the cleanup result is
+        still returned as successful since autovacuum will eventually reclaim
+        dead tuples via the tuned scale_factor settings in init.sql.
+        """
+        for attempt in range(1, self.VACUUM_MAX_RETRIES + 1):
+            vac_conn = None
+            try:
+                vac_conn = psycopg2.connect(**self.conn_params)
+                vac_conn.autocommit = True
+                with vac_conn.cursor() as cur:
+                    # Enforce a hard timeout so a blocked VACUUM cannot stall
+                    # the next cleanup cycle or hold a connection indefinitely.
+                    cur.execute(f"SET statement_timeout = '{self.VACUUM_TIMEOUT_SECS}s'")
+                    cur.execute("VACUUM ANALYZE logs")
+                logger.info("Post-cleanup VACUUM ANALYZE complete (attempt %d/%d)",
+                            attempt, self.VACUUM_MAX_RETRIES)
+                return  # success — exit retry loop
+            except psycopg2.errors.QueryCanceled:
+                # statement_timeout fired — VACUUM was taking too long.
+                # Do not retry: if it timed out once it will time out again.
+                logger.warning(
+                    "Post-cleanup VACUUM ANALYZE cancelled after %ds (attempt %d) — "
+                    "autovacuum will handle remaining dead tuples",
+                    self.VACUUM_TIMEOUT_SECS, attempt,
+                )
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Post-cleanup VACUUM ANALYZE failed on attempt %d/%d: %s",
+                    attempt, self.VACUUM_MAX_RETRIES, exc,
+                )
+                if attempt >= self.VACUUM_MAX_RETRIES:
+                    logger.warning(
+                        "Post-cleanup VACUUM ANALYZE exhausted %d retries — "
+                        "autovacuum will handle remaining dead tuples",
+                        self.VACUUM_MAX_RETRIES,
+                    )
+                else:
+                    time.sleep(0.5)  # brief backoff before retry
+            finally:
+                if vac_conn:
+                    try:
+                        vac_conn.close()
+                    except Exception:
+                        pass  # ignore close errors
 
     def get_stats(self) -> dict:
         """Get basic stats for health check / logging."""

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -1056,6 +1056,10 @@ END $$;""",
     # ── Retention cleanup ────────────────────────────────────────────────────
 
     RETENTION_BATCH_SIZE = 5_000
+    # Only run an explicit VACUUM ANALYZE after cleanup when the number of
+    # deleted rows is above this threshold.  Trivial runs (a handful of rows)
+    # are handled by tuned autovacuum, avoiding the cost of a full-table scan.
+    VACUUM_MIN_DELETED = 1_000
 
     @staticmethod
     def validate_retention_days(general_days: int, dns_days: int):
@@ -1241,22 +1245,30 @@ END $$;""",
                     result['deleted_so_far'], result['dns_deleted'],
                     result['non_dns_deleted'], general_days, dns_days)
         if result['deleted_so_far'] > 0:
-            # Run VACUUM ANALYZE after bulk deletes so dead tuples are reclaimed
-            # immediately, not left for autovacuum to find on its next cycle.
+            # Only run an explicit VACUUM ANALYZE when enough rows were deleted
+            # to justify the full-table scan cost.  Smaller cleanups are handled
+            # promptly by the tuned autovacuum settings in init.sql.
             # VACUUM cannot run inside a transaction — use a dedicated ephemeral
             # connection (never returned to the pool) so autocommit mode cannot
             # leak back to other callers.
-            try:
-                vac_conn = psycopg2.connect(**self.conn_params)
+            if result['deleted_so_far'] >= self.VACUUM_MIN_DELETED:
                 try:
-                    vac_conn.autocommit = True
-                    with vac_conn.cursor() as cur:
-                        cur.execute("VACUUM ANALYZE logs")
-                    logger.info("Post-cleanup VACUUM ANALYZE complete")
-                finally:
-                    vac_conn.close()
-            except Exception as exc:
-                logger.warning("Post-cleanup VACUUM ANALYZE failed (non-fatal): %s", exc)
+                    vac_conn = psycopg2.connect(**self.conn_params)
+                    try:
+                        vac_conn.autocommit = True
+                        with vac_conn.cursor() as cur:
+                            cur.execute("VACUUM ANALYZE logs")
+                        logger.info("Post-cleanup VACUUM ANALYZE complete")
+                    finally:
+                        vac_conn.close()
+                except Exception as exc:
+                    logger.warning("Post-cleanup VACUUM ANALYZE failed (non-fatal): %s", exc)
+            else:
+                logger.debug(
+                    "Post-cleanup VACUUM skipped (deleted=%d < threshold=%d); "
+                    "autovacuum will handle remaining dead tuples",
+                    result['deleted_so_far'], self.VACUUM_MIN_DELETED,
+                )
         return result
 
     def get_stats(self) -> dict:

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -692,6 +692,15 @@ END $$;""",
                 autovacuum_analyze_scale_factor = 0.02,
                 autovacuum_vacuum_cost_limit    = 10000
             )""",
+            # Log autovacuum runs that exceed 60 s so operators can verify
+            # the tuned scale_factor is firing after large retention cleanups.
+            # Requires ALTER DATABASE privilege — skipped silently if missing.
+            """DO $$ BEGIN
+                EXECUTE format(
+                    'ALTER DATABASE %I SET log_autovacuum_min_duration = ''60000''',
+                    current_database()
+                );
+            END $$""",
         ]
         try:
             with self.get_conn() as conn:

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -355,8 +355,8 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
     pull_blacklist()
 
     # Run retention cleanup once at startup so the first cleanup does not have
-    # to wait up to RETENTION_INTERVAL_HOURS before executing.
-    retention_cleanup()
+    # to wait until the scheduled daily window before executing.
+    _retention_cleanup(db)
 
     while True:
         _scheduler_tick(db)

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -354,6 +354,10 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
     time.sleep(30)
     pull_blacklist()
 
+    # Run retention cleanup once at startup so the first cleanup does not have
+    # to wait up to RETENTION_INTERVAL_HOURS before executing.
+    retention_cleanup()
+
     while True:
         _scheduler_tick(db)
         time.sleep(10)

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -65,6 +65,7 @@ class SyslogReceiver:
     HEARTBEAT_INTERVAL = 60  # Log heartbeat every 60 seconds
 
     def __init__(self, db: Database, enricher: Enricher):
+        """Create the receiver — does not open the socket until start() is called."""
         self.db = db
         self.enricher = enricher
         self.sock = None
@@ -318,6 +319,7 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
     """Background thread for scheduled tasks (retention cleanup, stats, blacklist)."""
 
     def log_stats():
+        """Log current DB and enrichment statistics at DEBUG level."""
         try:
             db_stats = db.get_stats()
             enrich_stats = enricher.get_stats()
@@ -327,6 +329,7 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
             logger.error("Failed to get stats: %s", e)
 
     def pull_blacklist():
+        """Fetch the latest IP blacklist and store it in the database."""
         if blacklist_fetcher:
             try:
                 blacklist_fetcher.fetch_and_store()
@@ -334,6 +337,7 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
                 logger.error("Blacklist pull failed: %s", e)
 
     def refresh_wan_ip():
+        """Refresh WAN/gateway identity from recent log data (no-op when UniFi is active)."""
         _refresh_network_identity_from_logs(db)
 
     schedule.every(STATS_INTERVAL_MINUTES).minutes.do(log_stats)
@@ -358,6 +362,7 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main():
+    """Entrypoint: initialise the database, enricher, and syslog receiver."""
     # Build connection params from environment
     conn_params = build_conn_params()
     logger.info("Database: %s mode (host=%s:%s, db=%s)",
@@ -427,6 +432,7 @@ def main():
 
     # Handle graceful shutdown
     def shutdown(signum, frame):
+        """Handle SIGTERM/SIGINT: flush pending logs and exit cleanly."""
         logger.info("Received signal %d, shutting down...", signum)
         receiver.stop()
         unifi_api.stop_polling()
@@ -437,6 +443,7 @@ def main():
 
     # Handle GeoIP database reload
     def reload_geoip(signum, frame):
+        """Handle SIGUSR1: hot-reload GeoIP databases without restarting."""
         logger.info("Received SIGUSR1, reloading GeoIP databases...")
         enricher.reload_geoip()
 


### PR DESCRIPTION
## Summary

Fixes the second part of #92: the **database grows unbounded** (~10 GB / 2 days) because dead tuples from batch deletes are not reclaimed fast enough by autovacuum.

### Analysis

**Why the database keeps growing despite retention cleanup:**

`run_retention_cleanup()` deletes rows in 5 000-row batches, committing after each batch so PostgreSQL autovacuum can reclaim dead tuples. However, autovacuum's default `autovacuum_vacuum_scale_factor = 0.2` means it won't trigger until **20% of the table's rows are dead**. On a 48 GB table with millions of rows this threshold is never reached quickly — dead tuples accumulate, bloating both the table and its indexes, and `pg_total_relation_size` never decreases even after a successful cleanup.

### Modifications

**`init.sql`**
```sql
ALTER TABLE logs SET (
    autovacuum_vacuum_scale_factor  = 0.01,   -- trigger at 1% dead tuples (was 20%)
    autovacuum_vacuum_cost_delay    = 2,       -- lower I/O throttle for faster vacuuming
    autovacuum_analyze_scale_factor = 0.02,
    autovacuum_vacuum_cost_limit    = 10000   -- higher I/O budget per worker cycle
);
-- Log autovacuum operations for production observability
ALTER DATABASE "unifi_logs" SET log_autovacuum_min_duration = '60000';
```

**`receiver/db.py` — `_ensure_schema()` migrations**

The `ALTER TABLE` and `ALTER DATABASE` statements are idempotent and included in `_ensure_schema()` so:
- **New installations** apply the tuning via `init.sql` on first boot
- **Existing installations** (the ones actually hitting issue #92 with bloated 48GB databases) apply the tuning on next container restart via the migration system

This ensures all deployments receive the autovacuum fix, not only fresh installs.

**`receiver/db.py` — `run_retention_cleanup()` and `_run_explicit_vacuum()`**

After a successful cleanup run, issue `VACUUM ANALYZE logs` explicitly as a backstop for high-ingestion periods when autovacuum cannot keep pace between cycles.

Production-hardened behaviors:
- **Threshold gating**: explicit VACUUM only fires when `deleted_so_far >= VACUUM_MIN_DELETED` (5 000 rows = one full batch). Sub-batch cleanups are cheap enough for tuned autovacuum alone — avoids unnecessary full-table scans on trivial runs.
- **Timeout enforcement**: `VACUUM_TIMEOUT_SECS = 300` — a `statement_timeout` is set on the ephemeral connection so a stuck VACUUM cannot stall the next cleanup cycle or hold a connection indefinitely. Timeout is logged as a warning and not retried.
- **Retry logic**: `VACUUM_MAX_RETRIES = 2` — transient failures (connection lost, lock timeout) are retried with 0.5 s backoff before giving up.
- **Ephemeral connection**: `VACUUM` cannot run inside a transaction, so a dedicated `psycopg2.connect()` call is used (never returned to the pool — autocommit mode cannot leak to other callers).
- **Non-fatal**: all VACUUM failures are logged as warnings; the cleanup result is still returned as successful.

**`receiver/main.py`**

Retention cleanup runs once at startup (in addition to the daily scheduled window) so the first cleanup fires at launch rather than being deferred to the configured daily time. Schedule remains `schedule.every().day.at(HH:MM)` with the user-configurable `RETENTION_TIME` value.

### Verification

1. After deploying:
   ```sql
   SELECT n_dead_tup, last_autovacuum, pg_size_pretty(pg_total_relation_size('logs'))
   FROM pg_stat_user_tables WHERE relname = 'logs';
   ```
   `n_dead_tup` should decrease after each cleanup run; `last_autovacuum` should become more recent.
2. Click "Run Cleanup Now" in the UI — confirm `pg_total_relation_size('logs')` shrinks afterwards.
3. Check container logs for `Post-cleanup VACUUM ANALYZE complete` (only fires when ≥ 5 000 rows deleted).
4. Confirm autovacuum tuning is applied:
   ```sql
   SELECT reloptions FROM pg_class WHERE relname = 'logs';
   ```
5. Confirm autovacuum logging is active:
   ```sql
   SELECT n_dead_tup, last_autovacuum FROM pg_stat_user_tables WHERE relname = 'logs';
   ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database maintenance configuration with more aggressive log cleanup
  * Added logging for slow maintenance operations (exceeding 60 seconds) for better visibility
  * Improved retention cleanup execution at startup with explicit maintenance and timeout protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #102
