### PR TITLE
fix(abuseipdb): make the integration usable on the free tier

### DIFF
--- a/receiver/backfill.py
+++ b/receiver/backfill.py
@@ -164,10 +164,19 @@ class BackfillTask:
         from db import get_wan_ips_from_config
 
         budget = self.abuseipdb.remaining_budget
-        if budget == 0:
+        # Bootstrap rule: mirror _process_queue. When rate-limit state is
+        # unknown (startup, _rate_limit_remaining is None), remaining_budget
+        # returns 0 but _check_rate_limit will allow one call. Without this,
+        # stale re-enrichment never bootstraps on a fresh install.
+        allow_bootstrap = (
+            budget == 0
+            and self.abuseipdb.enabled
+            and self.abuseipdb._rate_limit_remaining is None
+        )
+        if budget == 0 and not allow_bootstrap:
             return 0
 
-        batch_size = min(STALE_REENRICH_BATCH, budget)
+        batch_size = min(STALE_REENRICH_BATCH, max(budget, 1))
         stale_ips = self.db.get_stale_threat_candidates(limit=batch_size)
         if not stale_ips:
             return 0

--- a/receiver/blacklist.py
+++ b/receiver/blacklist.py
@@ -8,10 +8,11 @@ Pre-seeds ip_threats cache so blocked IPs get instant scores without API calls.
 
 import ipaddress
 import os
+import time
 import logging
 import requests
 
-from db import get_config, get_wan_ips_from_config
+from db import get_config, set_config, get_wan_ips_from_config
 
 logger = logging.getLogger('blacklist')
 
@@ -93,6 +94,14 @@ class BlacklistFetcher:
             # Bulk upsert into ip_threats
             count = self.db.bulk_upsert_threats(entries)
             logger.info("Blacklist: fetched %d IPs, upserted %d into ip_threats", len(entries), count)
+            if count:
+                # Record the successful pull so startup gating in main.py can
+                # skip redundant /blacklist calls within ABUSEIPDB_BLACKLIST_MIN_INTERVAL_HOURS.
+                # Free-tier quota is 5/day — restarts must not burn it.
+                try:
+                    set_config(self.db, 'last_blacklist_pull_at', int(time.time()))
+                except Exception:
+                    logger.exception("Failed to persist last_blacklist_pull_at")
             return count
 
         except requests.Timeout:

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -334,6 +334,18 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
                 logger.error("Blacklist pull failed: %s", e)
 
     def pull_blacklist_startup():
+        """Gated startup variant of pull_blacklist.
+
+        Reserves the free-tier /blacklist quota (5/day) by skipping the pull
+        when either of two conditions hold:
+
+        - ABUSEIPDB_BLACKLIST_SKIP_STARTUP is truthy (kill-switch).
+        - last_blacklist_pull_at in system_config is within
+          ABUSEIPDB_BLACKLIST_MIN_INTERVAL_HOURS (default 6h).
+
+        The scheduled 04:00 daily pull is unaffected — it calls the bare
+        pull_blacklist().
+        """
         if not blacklist_fetcher:
             return
         skip_env = os.environ.get('ABUSEIPDB_BLACKLIST_SKIP_STARTUP', '').strip().lower()

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -333,6 +333,32 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
             except Exception as e:
                 logger.error("Blacklist pull failed: %s", e)
 
+    def pull_blacklist_startup():
+        if not blacklist_fetcher:
+            return
+        skip_env = os.environ.get('ABUSEIPDB_BLACKLIST_SKIP_STARTUP', '').strip().lower()
+        if skip_env in ('1', 'true', 'yes', 'y'):
+            logger.info("Blacklist startup pull skipped (ABUSEIPDB_BLACKLIST_SKIP_STARTUP set)")
+            return
+        try:
+            interval_hours = float(os.environ.get('ABUSEIPDB_BLACKLIST_MIN_INTERVAL_HOURS', '6'))
+        except (TypeError, ValueError):
+            interval_hours = 6.0
+        last_pull = get_config(db, 'last_blacklist_pull_at', None)
+        if last_pull is not None:
+            try:
+                last_pull_f = float(last_pull)
+                age_seconds = time.time() - last_pull_f
+                if age_seconds < interval_hours * 3600:
+                    logger.info(
+                        "Blacklist startup pull skipped (last pull %.1fh ago, threshold %.1fh)",
+                        age_seconds / 3600.0, interval_hours,
+                    )
+                    return
+            except (TypeError, ValueError):
+                pass
+        pull_blacklist()
+
     def refresh_wan_ip():
         _refresh_network_identity_from_logs(db)
 
@@ -346,9 +372,10 @@ def run_scheduler(db: Database, enricher: Enricher, blacklist_fetcher: Blacklist
     logger.info("Scheduler started — stats every %dm, blacklist daily at 04:00, auth cleanup daily at 03:30",
                  STATS_INTERVAL_MINUTES)
 
-    # Initial blacklist pull after 30s startup delay
+    # Initial blacklist pull after 30s startup delay — gated to avoid burning
+    # the /blacklist quota (5/day on the free tier) on every container restart.
     time.sleep(30)
-    pull_blacklist()
+    pull_blacklist_startup()
 
     while True:
         _scheduler_tick(db)

--- a/receiver/routes/abuseipdb.py
+++ b/receiver/routes/abuseipdb.py
@@ -58,27 +58,40 @@ def enrich_ip(ip: str):
     # Budget check: use centralized AbuseIPDB stats from enricher DB
     budget_stats = get_abuseipdb_stats(enricher_db)
     if budget_stats:
-        # Block if actively paused (429 back-off)
-        paused_until = budget_stats.get('paused_until')
-        if paused_until:
+        # Bootstrap rule: when no /check call has ever populated rate-limit
+        # state (limit/remaining both None) and no active 429 pause, allow one
+        # call through so subsequent callers see populated state.
+        paused_active = False
+        paused_until_val = budget_stats.get('paused_until')
+        if paused_until_val:
             try:
-                if time.time() < float(paused_until):
-                    raise HTTPException(status_code=429, detail="AbuseIPDB paused (rate limited) — try later")
+                paused_active = time.time() < float(paused_until_val)
             except (ValueError, TypeError):
-                pass
-        remaining = budget_stats.get('remaining', 0) or 0
-        if remaining <= 0:
-            # Check if quota has renewed since stats were written
-            reset_at = budget_stats.get('reset_at')
-            quota_renewed = False
-            if reset_at is not None:
-                try:
-                    quota_renewed = time.time() > float(reset_at)
-                except (ValueError, TypeError):
-                    pass
-            if not quota_renewed:
-                raise HTTPException(status_code=429, detail="No API budget remaining — resets daily")
-            logger.info("Manual enrich: quota reset detected (reset_at %s passed), allowing call", reset_at)
+                paused_active = False
+        is_bootstrap = (
+            budget_stats.get('limit') is None
+            and budget_stats.get('remaining') is None
+            and not paused_active
+        )
+        if is_bootstrap:
+            logger.info("Manual enrich: bootstrap call (no prior /check rate-limit state)")
+        else:
+            # Block if actively paused (429 back-off)
+            if paused_active:
+                raise HTTPException(status_code=429, detail="AbuseIPDB paused (rate limited) — try later")
+            remaining = budget_stats.get('remaining', 0) or 0
+            if remaining <= 0:
+                # Check if quota has renewed since stats were written
+                reset_at = budget_stats.get('reset_at')
+                quota_renewed = False
+                if reset_at is not None:
+                    try:
+                        quota_renewed = time.time() > float(reset_at)
+                    except (ValueError, TypeError):
+                        pass
+                if not quota_renewed:
+                    raise HTTPException(status_code=429, detail="No API budget remaining — resets daily")
+                logger.info("Manual enrich: quota reset detected (reset_at %s passed), allowing call", reset_at)
 
     # Clear from memory cache
     abuseipdb.cache.delete(ip)

--- a/receiver/tests/test_backfill_bootstrap.py
+++ b/receiver/tests/test_backfill_bootstrap.py
@@ -1,0 +1,74 @@
+"""Tests for backfill._reenrich_stale_threats bootstrap allowance (Patch 2).
+
+When the AbuseIPDB rate-limit state has never been populated
+(_rate_limit_remaining is None), remaining_budget returns 0 — but the
+enricher's _check_rate_limit will still permit exactly one call. The
+re-enrichment loop must take that path to bootstrap state on a fresh
+install, mirroring _process_queue.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import backfill
+
+
+def _make_task(rate_limit_remaining, stale_ips):
+    db = MagicMock()
+    db.get_stale_threat_candidates = MagicMock(return_value=list(stale_ips))
+    # get_conn / cursor for the UPDATE ip_threats path
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    db.get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+    db.get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+    enricher = MagicMock()
+    abuseipdb = MagicMock()
+    abuseipdb.enabled = True
+    abuseipdb._rate_limit_remaining = rate_limit_remaining
+    abuseipdb.remaining_budget = 0  # bootstrap state: budget always reports 0 if remaining is None
+    abuseipdb.cache = MagicMock()
+    # lookup returns a result with threat_score so the loop counts it as a hit.
+    abuseipdb.lookup = MagicMock(return_value={'threat_score': 50})
+    enricher.abuseipdb = abuseipdb
+    enricher.geoip = MagicMock()
+    enricher.rdns = MagicMock()
+
+    task = backfill.BackfillTask(db, enricher)
+    return task, abuseipdb
+
+
+class TestReenrichStaleBootstrap:
+    def test_bootstrap_when_rate_limit_unknown_makes_one_call(self, monkeypatch):
+        monkeypatch.setattr(backfill, 'get_service_mappings', MagicMock(return_value={}))
+        # No sleep in tests
+        monkeypatch.setattr(backfill.time, 'sleep', lambda *_: None)
+        # Avoid touching db helper
+        import sys as _sys
+        fake_db_mod = MagicMock()
+        fake_db_mod.get_wan_ips_from_config = MagicMock(return_value=[])
+        monkeypatch.setitem(_sys.modules, 'db', fake_db_mod)
+
+        task, abuseipdb = _make_task(rate_limit_remaining=None, stale_ips=['1.1.1.1'])
+
+        task._reenrich_stale_threats()
+
+        assert abuseipdb.lookup.call_count == 1, "bootstrap must call lookup exactly once"
+
+    def test_real_exhaustion_makes_zero_calls(self, monkeypatch):
+        monkeypatch.setattr(backfill, 'get_service_mappings', MagicMock(return_value={}))
+        monkeypatch.setattr(backfill.time, 'sleep', lambda *_: None)
+        import sys as _sys
+        fake_db_mod = MagicMock()
+        fake_db_mod.get_wan_ips_from_config = MagicMock(return_value=[])
+        monkeypatch.setitem(_sys.modules, 'db', fake_db_mod)
+
+        task, abuseipdb = _make_task(rate_limit_remaining=0, stale_ips=['1.1.1.1', '2.2.2.2'])
+
+        result = task._reenrich_stale_threats()
+
+        assert result == 0
+        assert abuseipdb.lookup.call_count == 0, "real exhaustion must NOT call lookup"

--- a/receiver/tests/test_blacklist.py
+++ b/receiver/tests/test_blacklist.py
@@ -1,0 +1,92 @@
+"""Tests for BlacklistFetcher.fetch_and_store — free-tier resilience.
+
+Covers Patch 1's blacklist-side acceptance criteria:
+- Timestamp persisted only on successful pull.
+- HTTP 429 does NOT persist timestamp.
+- Empty/zero-count response does NOT persist timestamp.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import blacklist
+
+
+@pytest.fixture
+def db_with_no_wan():
+    """A MagicMock db whose get_wan_ips/gateway_ips return empty lists."""
+    db = MagicMock()
+    db.bulk_upsert_threats = MagicMock(side_effect=lambda entries: len(entries))
+    return db
+
+
+def _mk_response(status=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json = MagicMock(return_value=json_data or {})
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestBlacklistFetcherTimestamp:
+    def test_success_writes_timestamp(self, db_with_no_wan, monkeypatch):
+        monkeypatch.setattr(blacklist, 'get_wan_ips_from_config', lambda db: [])
+        monkeypatch.setattr(blacklist, 'get_config', lambda db, key, default=None: None if key == 'gateway_ips' else default)
+        set_config_mock = MagicMock()
+        monkeypatch.setattr(blacklist, 'set_config', set_config_mock)
+        monkeypatch.setattr(blacklist, 'time', MagicMock(time=MagicMock(return_value=1_700_000_000.0)))
+
+        fetcher = blacklist.BlacklistFetcher(db_with_no_wan, api_key='fake-key')
+        fake_data = {'data': [{'ipAddress': '1.2.3.4', 'abuseConfidenceScore': 92}]}
+
+        with patch.object(blacklist.requests, 'get', return_value=_mk_response(200, fake_data)):
+            count = fetcher.fetch_and_store()
+
+        assert count == 1
+        set_config_mock.assert_called_once()
+        args, _ = set_config_mock.call_args
+        assert args[1] == 'last_blacklist_pull_at'
+        assert args[2] == 1_700_000_000  # int(time.time())
+
+    def test_rate_limited_does_not_write_timestamp(self, db_with_no_wan, monkeypatch):
+        monkeypatch.setattr(blacklist, 'get_wan_ips_from_config', lambda db: [])
+        monkeypatch.setattr(blacklist, 'get_config', lambda db, key, default=None: None if key == 'gateway_ips' else default)
+        set_config_mock = MagicMock()
+        monkeypatch.setattr(blacklist, 'set_config', set_config_mock)
+
+        fetcher = blacklist.BlacklistFetcher(db_with_no_wan, api_key='fake-key')
+
+        with patch.object(blacklist.requests, 'get', return_value=_mk_response(429)):
+            count = fetcher.fetch_and_store()
+
+        assert count == 0
+        set_config_mock.assert_not_called()
+
+    def test_empty_response_does_not_write_timestamp(self, db_with_no_wan, monkeypatch):
+        monkeypatch.setattr(blacklist, 'get_wan_ips_from_config', lambda db: [])
+        monkeypatch.setattr(blacklist, 'get_config', lambda db, key, default=None: None if key == 'gateway_ips' else default)
+        set_config_mock = MagicMock()
+        monkeypatch.setattr(blacklist, 'set_config', set_config_mock)
+
+        fetcher = blacklist.BlacklistFetcher(db_with_no_wan, api_key='fake-key')
+
+        with patch.object(blacklist.requests, 'get', return_value=_mk_response(200, {'data': []})):
+            count = fetcher.fetch_and_store()
+
+        assert count == 0
+        set_config_mock.assert_not_called()
+
+    def test_no_api_key_does_not_write_timestamp(self, db_with_no_wan, monkeypatch):
+        monkeypatch.setenv('ABUSEIPDB_API_KEY', '')
+        set_config_mock = MagicMock()
+        monkeypatch.setattr(blacklist, 'set_config', set_config_mock)
+
+        fetcher = blacklist.BlacklistFetcher(db_with_no_wan, api_key='')
+
+        with patch.object(blacklist.requests, 'get') as get_mock:
+            count = fetcher.fetch_and_store()
+
+        assert count == 0
+        get_mock.assert_not_called()
+        set_config_mock.assert_not_called()

--- a/receiver/tests/test_routes_abuseipdb_enrich.py
+++ b/receiver/tests/test_routes_abuseipdb_enrich.py
@@ -1,0 +1,113 @@
+"""Tests for routes/abuseipdb.py POST /api/enrich/{ip} bootstrap allowance (Patch 3).
+
+When AbuseIPDB stats show no /check has ever been made (limit=None,
+remaining=None) and there is no active 429 pause, the endpoint must allow
+the call through so subsequent callers see populated rate-limit state.
+Real exhaustion and active pause must still return 429.
+"""
+
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def enrich_client(monkeypatch):
+    """FastAPI TestClient over routes/abuseipdb.py with deps & enrichment mocked.
+
+    Mirrors the test_routes_health.py fixture pattern: replace deps + db +
+    enrichment in sys.modules before importing the route module. `from X
+    import Y` captures Y at import time, so per-test stat overrides must be
+    applied via setattr on the route module itself — not the source module.
+    """
+    for mod_name in list(sys.modules):
+        if mod_name.startswith('routes'):
+            monkeypatch.delitem(sys.modules, mod_name, raising=False)
+
+    abuseipdb_mock = MagicMock()
+    abuseipdb_mock.enabled = True
+    abuseipdb_mock.cache = MagicMock()
+    abuseipdb_mock.lookup = MagicMock(return_value={
+        'threat_score': 80, 'threat_categories': ['test'],
+        'abuse_usage_type': 'isp', 'abuse_hostnames': [],
+        'abuse_total_reports': 2, 'abuse_last_reported': None,
+        'abuse_is_whitelisted': False, 'abuse_is_tor': False,
+    })
+    abuseipdb_mock.remaining_budget = 998
+
+    enricher_db_mock = MagicMock()
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.rowcount = 0
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    enricher_db_mock.get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+    enricher_db_mock.get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_deps = MagicMock()
+    mock_deps.abuseipdb = abuseipdb_mock
+    mock_deps.enricher_db = enricher_db_mock
+    monkeypatch.setitem(sys.modules, 'deps', mock_deps)
+
+    mock_db = MagicMock()
+    mock_db.get_config = MagicMock(return_value=[])
+    mock_db.get_wan_ips_from_config = MagicMock(return_value=[])
+    monkeypatch.setitem(sys.modules, 'db', mock_db)
+
+    enrichment_mock = MagicMock()
+    enrichment_mock.is_public_ip = MagicMock(return_value=True)
+    enrichment_mock.get_abuseipdb_stats = MagicMock(return_value=None)
+    monkeypatch.setitem(sys.modules, 'enrichment', enrichment_mock)
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    import routes.abuseipdb as route_mod
+
+    # Rebind the from-imported symbols on the route module so per-test
+    # setattr(route_mod, 'get_abuseipdb_stats', ...) overrides take effect.
+    monkeypatch.setattr(route_mod, 'is_public_ip', lambda ip: True)
+
+    app = FastAPI()
+    app.include_router(route_mod.router)
+    return TestClient(app), abuseipdb_mock, route_mod, monkeypatch
+
+
+class TestEnrichIpBootstrap:
+    def test_bootstrap_allows_call(self, enrich_client):
+        client, abuseipdb_mock, route_mod, monkeypatch = enrich_client
+        # Bootstrap shape: limit + remaining both None, no pause.
+        monkeypatch.setattr(route_mod, 'get_abuseipdb_stats', MagicMock(return_value={
+            'limit': None, 'remaining': None, 'reset_at': None, 'paused_until': None,
+        }))
+
+        resp = client.post('/api/enrich/8.8.8.8')
+
+        assert resp.status_code == 200, resp.text
+        abuseipdb_mock.lookup.assert_called_once_with('8.8.8.8')
+
+    def test_real_exhaustion_returns_429(self, enrich_client):
+        client, abuseipdb_mock, route_mod, monkeypatch = enrich_client
+        future = time.time() + 3600
+        monkeypatch.setattr(route_mod, 'get_abuseipdb_stats', MagicMock(return_value={
+            'limit': 1000, 'remaining': 0, 'reset_at': future, 'paused_until': None,
+        }))
+
+        resp = client.post('/api/enrich/8.8.8.8')
+
+        assert resp.status_code == 429
+        abuseipdb_mock.lookup.assert_not_called()
+
+    def test_active_pause_returns_429(self, enrich_client):
+        client, abuseipdb_mock, route_mod, monkeypatch = enrich_client
+        future = time.time() + 600
+        # Even with bootstrap-shaped limit/remaining, an active pause must block.
+        monkeypatch.setattr(route_mod, 'get_abuseipdb_stats', MagicMock(return_value={
+            'limit': None, 'remaining': None, 'reset_at': None, 'paused_until': future,
+        }))
+
+        resp = client.post('/api/enrich/8.8.8.8')
+
+        assert resp.status_code == 429
+        abuseipdb_mock.lookup.assert_not_called()


### PR DESCRIPTION
# fix(abuseipdb): make the integration usable on the free tier

Fixes #108

Three independent fixes that make the AbuseIPDB integration usable on the free tier (5 `/blacklist` + 1000 `/check` per day). Each is a separate commit and could trivially be split into three PRs if you prefer — let me know.

## Why

On the free tier, the integration becomes inert after a few routine container recreates:

- `/blacklist` quota (5/day) gets burned by the unconditional startup pull, so subsequent legitimate refreshes return HTTP 429.
- `/check` rate-limit state is populated only from response headers, but two of the three callers gate on `remaining_budget == 0` and never issue the one bootstrap call that would populate those headers. Result: 10K+ blacklist-seeded IPs sit in `ip_threats` with `abuse_usage_type / abuse_hostnames / abuse_total_reports / abuse_is_tor = NULL` forever, and `POST /api/enrich/{ip}` rejects every request as "No API budget remaining" even though no call has been made.

Observed on a real instance: `/tmp/abuseipdb_stats.json` = `{"limit": null, "remaining": null, …}` after ~24h of uptime and several restarts.

## What changed

### Commit 1 — `fix(abuseipdb): gate /blacklist startup pull to preserve free-tier quota`

`receiver/blacklist.py`, `receiver/main.py`, `receiver/tests/test_blacklist.py`

- `BlacklistFetcher.fetch_and_store()` now persists `last_blacklist_pull_at` (UNIX seconds) to `system_config` **only** when `bulk_upsert_threats` returns a non-zero count. 429 / empty / exception leave it untouched so the next restart still retries.
- `run_scheduler` gets a new closure `pull_blacklist_startup()`:
  - reads `ABUSEIPDB_BLACKLIST_SKIP_STARTUP` (truthy: `1`, `true`, `yes`, `y`) as a hard kill-switch;
  - otherwise reads `ABUSEIPDB_BLACKLIST_MIN_INTERVAL_HOURS` (float, default `6.0`) and skips if the last successful pull is within that window;
  - logs the decision at INFO.
- The scheduled `04:00` daily job still calls the bare `pull_blacklist()` — daily cadence is preserved.

### Commit 2 — `fix(abuseipdb): allow bootstrap call in _reenrich_stale_threats`

`receiver/backfill.py`, `receiver/tests/test_backfill_bootstrap.py`

`_reenrich_stale_threats` now mirrors the bootstrap pattern already used in `_process_queue`:

```python
budget = self.abuseipdb.remaining_budget
allow_bootstrap = (
    budget == 0
    and self.abuseipdb.enabled
    and self.abuseipdb._rate_limit_remaining is None
)
if budget == 0 and not allow_bootstrap:
    return 0
batch_size = min(STALE_REENRICH_BATCH, max(budget, 1))
```

After the bootstrap call populates `_rate_limit_remaining`, subsequent hourly cycles flow normally. Real exhaustion (`_rate_limit_remaining == 0`) is unchanged.

### Commit 3 — `fix(abuseipdb): allow bootstrap in POST /api/enrich/{ip}`

`receiver/routes/abuseipdb.py`, `receiver/tests/test_routes_abuseipdb_enrich.py`

Detect bootstrap shape (`limit is None AND remaining is None AND no active pause`) and skip the remaining/paused budget checks. An active `paused_until` in the future still blocks with HTTP 429, so this does **not** bypass real rate-limiting from AbuseIPDB.

## Tests

Three new test files, one per patch, all using existing `tests/conftest.py` fixtures and the route-test pattern from `tests/test_routes_health.py`.

| Patch | Test | Asserts |
|---|---|---|
| 1 | `test_blacklist.py::test_success_writes_timestamp` | `set_config('last_blacklist_pull_at', int(time.time()))` called once |
| 1 | `test_blacklist.py::test_rate_limited_does_not_write_timestamp` | 429 → `set_config` not called |
| 1 | `test_blacklist.py::test_empty_response_does_not_write_timestamp` | empty `data` → not called |
| 1 | `test_blacklist.py::test_no_api_key_does_not_write_timestamp` | disabled enricher → no request, no write |
| 2 | `test_backfill_bootstrap.py::test_bootstrap_when_rate_limit_unknown_makes_one_call` | `_rate_limit_remaining is None` → exactly 1 `lookup()` call |
| 2 | `test_backfill_bootstrap.py::test_real_exhaustion_makes_zero_calls` | `_rate_limit_remaining == 0` → 0 calls |
| 3 | `test_routes_abuseipdb_enrich.py::test_bootstrap_allows_call` | bootstrap stats → 200 + 1 `lookup()` |
| 3 | `test_routes_abuseipdb_enrich.py::test_real_exhaustion_returns_429` | `remaining=0, reset_at=future` → 429 |
| 3 | `test_routes_abuseipdb_enrich.py::test_active_pause_returns_429` | `paused_until=future` → 429 even with bootstrap-shaped stats |

## Backwards compatibility / behavior matrix

| Scenario | Before | After |
|---|---|---|
| Fresh install, first start | startup pull fires | startup pull fires (`last_blacklist_pull_at` empty) |
| Restart within 6h of successful pull | startup pull fires, burns quota | **skipped**, INFO log line |
| `ABUSEIPDB_BLACKLIST_SKIP_STARTUP=true` | startup pull fires | **skipped** regardless of timestamp |
| 04:00 daily scheduled pull | runs | runs (unchanged) |
| Failed startup pull (429 / empty) | timestamp unchanged | timestamp unchanged (still retries next start) |
| `_reenrich_stale_threats` on fresh install | bails, no call ever made | makes 1 bootstrap call, populates state |
| Real `/check` exhaustion (`_rate_limit_remaining == 0`) | bails | bails (unchanged) |
| `POST /api/enrich/{ip}` on fresh install | HTTP 429 | HTTP 200, one `/check` call |
| `POST /api/enrich/{ip}` with `paused_until=future` | HTTP 429 | HTTP 429 (unchanged) |
| `POST /api/enrich/{ip}` with real exhaustion | HTTP 429 | HTTP 429 (unchanged) |

## New env vars

| Var | Default | Effect |
|---|---|---|
| `ABUSEIPDB_BLACKLIST_MIN_INTERVAL_HOURS` | `6.0` | Skip startup pull if last successful pull was within this many hours |
| `ABUSEIPDB_BLACKLIST_SKIP_STARTUP` | unset | Truthy (`1`/`true`/`yes`/`y`) → unconditionally skip startup pull (daily 04:00 still fires) |

## Out of scope (mentioning for completeness)

- `/blacklist` doesn't return per-call rate-limit headers — that's an AbuseIPDB API constraint.
- `STALE_DAYS = 4` left alone — reasonable for free-tier.
- Admin endpoint to manually trigger `/blacklist` — useful for recovery scenarios, but lower priority and not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New startup controls to avoid unnecessary blacklist calls on restart (skip flag and minimum-interval setting)

* **Improvements**
  * Allow a single "bootstrap" enrichment call when rate-limit state is unknown to recover gracefully
  * Persist timestamp of successful blacklist pulls to prevent redundant free-tier usage
  * Startup now delays briefly before performing conditional blacklist checks

* **Tests**
  * Added tests covering bootstrap, quota exhaustion, pause behavior, and blacklist timestamp persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmasarweh/UniFi-Insights-Plus/pull/109)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->