### PR TITLE
fix(receiver): catch parser exceptions to stop one-packet remote DoS

### DIFF
--- a/receiver/main.py
+++ b/receiver/main.py
@@ -83,6 +83,7 @@ class SyslogReceiver:
             'inserted': 0,
             'flush_errors': 0,
             'dropped': 0,
+            'parse_exceptions': 0,
         }
         self._load_disabled_types()
 
@@ -153,27 +154,44 @@ class SyslogReceiver:
         if not raw_log:
             return
 
-        parsed = parse_log(raw_log)
-        if parsed is None:
-            self.stats['failed'] += 1
-            logger.debug("Unparseable log from %s: %.100s...", addr, raw_log)
-            return
+        try:
+            parsed = parse_log(raw_log)
+            if parsed is None:
+                self.stats['failed'] += 1
+                logger.debug("Unparseable log from %s: %.100s...", addr, raw_log)
+                return
 
-        self.stats['parsed'] += 1
+            self.stats['parsed'] += 1
 
-        # Filter disabled log types before enrichment
-        log_type = parsed.get('log_type')
-        if log_type in self._disabled_log_types:
-            self.stats['filtered'] += 1
-            return
+            # Filter disabled log types before enrichment
+            log_type = parsed.get('log_type')
+            if log_type in self._disabled_log_types:
+                self.stats['filtered'] += 1
+                return
 
-        # Enrich with GeoIP, ASN, AbuseIPDB, rDNS
-        parsed = self.enricher.enrich(parsed)
+            # Enrich with GeoIP, ASN, AbuseIPDB, rDNS
+            parsed = self.enricher.enrich(parsed)
 
-        with self.batch_lock:
-            self.batch.append(parsed)
-            if len(self.batch) >= BATCH_SIZE:
-                self._flush_batch()
+            with self.batch_lock:
+                self.batch.append(parsed)
+                if len(self.batch) >= BATCH_SIZE:
+                    self._flush_batch()
+        except Exception:
+            # Never let a single malformed/edge-case packet kill the receiver
+            # thread. UDP/514 is reachable by any LAN host (and an attacker
+            # who can spoof source IPs over UDP); an unhandled exception here
+            # would crash the receiver and force a supervisord restart,
+            # losing in-flight packets — a one-packet remote DoS.
+            self.stats['parse_exceptions'] += 1
+            # Rate-limit the log line so an attacker can't fill disk with our
+            # own warnings: emit once per 100 exceptions, with the first.
+            if self.stats['parse_exceptions'] % 100 == 1:
+                logger.warning(
+                    "Unhandled exception processing packet from %s "
+                    "(total parse_exceptions=%d). Sample raw_log: %.200r",
+                    addr, self.stats['parse_exceptions'], raw_log,
+                    exc_info=True,
+                )
 
     def _maybe_flush_batch(self):
         """Flush batch if timeout elapsed."""

--- a/receiver/parsers.py
+++ b/receiver/parsers.py
@@ -188,7 +188,7 @@ def _get_syslog_tz():
         return timezone.utc
 
 
-def parse_syslog_timestamp(month: str, day: str, time_str: str) -> datetime:
+def parse_syslog_timestamp(month: str, day: str, time_str: str) -> datetime | None:
     """Parse syslog timestamp. Syslog doesn't include year, so we use current year.
 
     Syslog RFC3164 timestamps carry no timezone — they are in the sender's
@@ -200,18 +200,24 @@ def parse_syslog_timestamp(month: str, day: str, time_str: str) -> datetime:
     A simple ``ts > now`` check is too aggressive — if the gateway clock is
     even a few seconds ahead of the container clock, same-day logs get stamped
     with the previous year.
+
+    Returns None when the components don't form a valid datetime — an attacker
+    on the LAN can send a syslog packet with ``Feb 99 99:99:99`` that passes
+    the header regex but fails ``datetime()`` construction, and an unhandled
+    ValueError here would crash the receiver thread.
     """
     local_tz = _get_syslog_tz()
     now = datetime.now(local_tz)
     month_num = MONTHS.get(month, 1)
-    h, m, s = time_str.split(':')
-    year = now.year
-    # Handle year rollover: only when the log month is far ahead of now
-    # (e.g. log says December but we're in January → previous year's December)
-    if month_num - now.month > 6:
-        year -= 1
-    ts = datetime(year, month_num, int(day), int(h), int(m), int(s), tzinfo=local_tz)
-    return ts.astimezone(timezone.utc)
+    try:
+        h, m, s = time_str.split(':')
+        year = now.year
+        if month_num - now.month > 6:
+            year -= 1
+        ts = datetime(year, month_num, int(day), int(h), int(m), int(s), tzinfo=local_tz)
+        return ts.astimezone(timezone.utc)
+    except (ValueError, OverflowError):
+        return None
 
 
 def derive_direction(iface_in: str, iface_out: str, rule_name: str, src_ip: str = None, dst_ip: str = None) -> str:
@@ -503,6 +509,8 @@ def parse_log(raw_log: str) -> dict | None:
         raw_log = stripped
 
     timestamp = parse_syslog_timestamp(m.group('month'), m.group('day'), m.group('time'))
+    if timestamp is None:
+        return None
     body = m.group('body')
 
     log_type = detect_log_type(body)

--- a/receiver/tests/test_main_parser_resilience.py
+++ b/receiver/tests/test_main_parser_resilience.py
@@ -45,6 +45,15 @@ def receiver(monkeypatch):
 
 
 class TestHandleMessageResilience:
+    """Regression coverage for the C4 / VULN-001 one-packet remote DoS.
+
+    Each test forces an exception in a different layer of the parse pipeline
+    (real parser timestamp ValueError, mocked parse_log, mocked enricher.enrich)
+    and asserts the receiver swallows the exception, increments the
+    parse_exceptions counter, rate-limits its WARNING log, and keeps processing
+    subsequent packets.
+    """
+
     def test_malformed_timestamp_does_not_raise(self, receiver):
         # "Feb 99 99:99:99 host body" — passes the SYSLOG_HEADER regex but
         # the components are out of range. Before the fix, datetime() raised

--- a/receiver/tests/test_main_parser_resilience.py
+++ b/receiver/tests/test_main_parser_resilience.py
@@ -1,0 +1,113 @@
+"""Tests for SyslogReceiver._handle_message resilience to malformed packets.
+
+Security context: UDP/514 is bound to all interfaces (`::`) and accepts
+packets from any source. Before this fix, an unhandled exception in
+parse_log or enricher.enrich would crash the receiver thread, allowing a
+one-packet remote DoS. The handler now wraps the critical section in
+try/except and rate-limits the warning log so a sustained attack cannot
+fill the disk with warnings.
+
+Findings addressed:
+- C4 (Gemini VULN-001) — malformed packet → receiver thread crash
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def receiver(monkeypatch):
+    """Build a SyslogReceiver with heavy deps stubbed.
+
+    Mirrors test_main_retention_scheduler.py's main_module fixture: deps.py
+    runs wait_for_postgres() at import time, which blocks for 30 retries when
+    no DB is reachable. We stub the offending modules in sys.modules before
+    `import main`. We keep the REAL `parsers` module so test_malformed_timestamp
+    exercises the actual datetime() crash path.
+    """
+    import sys
+    for name in ('enrichment', 'backfill', 'blacklist',
+                 'unifi_api', 'pihole_api', 'routes.auth', 'deps', 'db'):
+        monkeypatch.setitem(sys.modules, name, MagicMock())
+
+    monkeypatch.delitem(sys.modules, 'main', raising=False)
+    from main import SyslogReceiver
+
+    db = MagicMock()
+    db.get_config = MagicMock(return_value=True)
+    enricher = MagicMock()
+    enricher.enrich = MagicMock(side_effect=lambda p: p)
+
+    r = SyslogReceiver(db, enricher)
+    r._disabled_log_types = set()
+    return r
+
+
+class TestHandleMessageResilience:
+    def test_malformed_timestamp_does_not_raise(self, receiver):
+        # "Feb 99 99:99:99 host body" — passes the SYSLOG_HEADER regex but
+        # the components are out of range. Before the fix, datetime() raised
+        # ValueError and that propagated up out of _handle_message.
+        data = b"Feb 99 99:99:99 host kernel: anything"
+        # Must not raise.
+        receiver._handle_message(data, ('1.2.3.4', 1234))
+        # The malformed packet should be counted as 'failed' (parse_log
+        # returns None when the timestamp is unparseable).
+        assert receiver.stats['failed'] >= 1
+
+    def test_parse_log_raising_is_swallowed(self, receiver, monkeypatch):
+        # Defense-in-depth: even if parse_log itself raises an unexpected
+        # exception (e.g. future regression in a downstream parser), the
+        # handler must not propagate.
+        import main as main_module
+        monkeypatch.setattr(main_module, 'parse_log',
+                            MagicMock(side_effect=RuntimeError("simulated parser bug")))
+
+        data = b"Feb  8 16:43:49 host kernel: anything"
+        receiver._handle_message(data, ('1.2.3.4', 1234))
+
+        assert receiver.stats['parse_exceptions'] == 1
+        # Receiver state is otherwise normal — batch is unaffected.
+        assert receiver.batch == []
+
+    def test_enricher_raising_is_swallowed(self, receiver, monkeypatch):
+        # If enricher.enrich raises, we must catch it. Same threat model.
+        receiver.enricher.enrich = MagicMock(side_effect=RuntimeError("simulated enricher bug"))
+
+        # Use a syslog header the real parser accepts so we reach enrich().
+        data = b"Feb  8 16:43:49 host kernel: [WAN_IN-B] IN=ppp0 OUT=br20 SRC=1.2.3.4 DST=10.0.0.5 PROTO=TCP SPT=1234 DPT=80"
+        receiver._handle_message(data, ('1.2.3.4', 1234))
+
+        assert receiver.stats['parse_exceptions'] == 1
+
+    def test_burst_of_bad_packets_logs_bounded_warnings(self, receiver, monkeypatch, caplog):
+        # An attacker sending 1000 malformed packets must not produce 1000
+        # WARNING log entries (which would fill the disk).
+        import main as main_module
+        monkeypatch.setattr(main_module, 'parse_log',
+                            MagicMock(side_effect=RuntimeError("boom")))
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger='__main__'):
+            for _ in range(1000):
+                receiver._handle_message(b"any payload", ('1.2.3.4', 1234))
+
+        assert receiver.stats['parse_exceptions'] == 1000
+        # Rate-limited at 1-per-100 starting from the first: expect ~10 warnings.
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert 1 <= len(warning_records) <= 12, \
+            f"expected ~10 rate-limited warnings, got {len(warning_records)}"
+
+    def test_normal_packet_after_bad_packet_still_works(self, receiver):
+        # Send a malformed packet, then a normal one. State must not be
+        # corrupted; the normal packet should be parsed and batched.
+        bad = b"Feb 99 99:99:99 host kernel: junk"
+        good = b"Feb  8 16:43:49 host kernel: [WAN_IN-B] IN=ppp0 OUT=br20 SRC=1.2.3.4 DST=10.0.0.5 PROTO=TCP SPT=1234 DPT=80"
+
+        receiver._handle_message(bad, ('attacker', 1234))
+        receiver._handle_message(good, ('gateway', 514))
+
+        # The good packet should have been parsed and added to the batch.
+        assert receiver.stats['parsed'] >= 1
+        assert len(receiver.batch) >= 1

--- a/receiver/tests/test_parsers.py
+++ b/receiver/tests/test_parsers.py
@@ -106,6 +106,29 @@ class TestParseSyslogTimestamp:
         ts = parse_syslog_timestamp('Feb', '8', '12:00:00')
         assert ts.tzinfo == timezone.utc
 
+    def test_out_of_range_day_returns_none(self, monkeypatch):
+        # Attacker-crafted packet: "Feb 99 12:00:00 host body" passes the
+        # SYSLOG_HEADER regex but datetime() raises ValueError on day=99.
+        monkeypatch.setenv('TZ', 'UTC')
+        assert parse_syslog_timestamp('Feb', '99', '12:00:00') is None
+
+    def test_out_of_range_hour_returns_none(self, monkeypatch):
+        monkeypatch.setenv('TZ', 'UTC')
+        assert parse_syslog_timestamp('Feb', '1', '99:00:00') is None
+
+    def test_out_of_range_minute_returns_none(self, monkeypatch):
+        monkeypatch.setenv('TZ', 'UTC')
+        assert parse_syslog_timestamp('Feb', '1', '12:99:00') is None
+
+    def test_out_of_range_second_returns_none(self, monkeypatch):
+        monkeypatch.setenv('TZ', 'UTC')
+        assert parse_syslog_timestamp('Feb', '1', '12:00:99') is None
+
+    def test_huge_int_returns_none(self, monkeypatch):
+        # OverflowError path: int() succeeds but datetime() can't represent
+        monkeypatch.setenv('TZ', 'UTC')
+        assert parse_syslog_timestamp('Feb', '1', '99999999999:00:00') is None
+
 
 # ── detect_log_type ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #110

## Why

Found in a multi-AI security review of the codebase. Reproducer:

```bash
echo "Feb 99 99:99:99 host kernel: anything" | nc -u -w0 <ULI-host> 514
```

The `SYSLOG_HEADER` regex accepts any digit count for day/hour/min/sec, so an attacker can craft a packet that passes the regex but causes `datetime(year, month_num, int(day), int(h), int(m), int(s), ...)` to raise `ValueError`. The exception propagates out of `parse_log` and out of `SyslogReceiver._handle_message` (which had no `try/except` around the parse path) and kills the receiver thread. Supervisord restarts the process, but in-flight packets are lost and a sustained attack creates a permanent restart loop.

The receiver binds to all interfaces on UDP/514 by default and accepts packets from any source, so this is reachable from any LAN host (or the public internet if the Docker port is not firewalled). Pre-auth remote DoS.

## What changed

Two layers of defense — intentional belt-and-suspenders:

### Layer 1: `receiver/parsers.py` — fix the known crash path

`parse_syslog_timestamp` now catches `ValueError` and `OverflowError` from `datetime()` construction and returns `None`. `parse_log` checks for `None` and returns `None`, matching the existing "unparseable log" code path so the downstream handler does not change.

### Layer 2: `receiver/main.py` — safety net for unforeseen future exceptions

`SyslogReceiver._handle_message` wraps the `parse_log` + filter + `enricher.enrich` + batch-append section in `try/except Exception`. New stats counter `parse_exceptions`; warnings rate-limited to one-per-100 so an attacker cannot fill the disk with our own warning messages.

## Tests

| File | Cases | Purpose |
|---|---|---|
| `tests/test_parsers.py` | +5 | `parse_syslog_timestamp` returns `None` for out-of-range day/hour/minute/second and overflow inputs |
| `tests/test_main_parser_resilience.py` (new) | +5 | Receiver doesn't propagate exceptions: malformed-timestamp packet, `parse_log` raising, `enricher.enrich` raising, burst of 1000 bad packets logs ≤12 warnings, state is preserved (good packet after bad still parses and batches) |

```
============================= test session starts ==============================
collected 627 items

...

============================= 627 passed in 2.19s ==============================
```

## Backwards compatibility

- **Normal traffic:** unchanged — valid timestamps still parse to UTC `datetime` as before.
- **Previously-unhandled malformed packets:** now counted in `stats['failed']` (timestamp-only error) or `stats['parse_exceptions']` (anything else); previously crashed the process.
- No schema, config, or API surface changes.

## Severity & priority

This is the first end-to-end network-reachable remote-DoS finding in the codebase. The fix is ~20 LOC of source + ~100 LOC of tests. Hopefully OK to land independently of the other (larger) hardening work from the same review round.

## Out of scope (deliberately)

The broader UDP/514 attack surface — source allowlist, per-source rate limiting, host-port binding to LAN interface only, dropping root in the container — is real but is a multi-file change that warrants its own review and PR. The fix here neutralizes the most acute path (one-packet crash) without taking on that scope.

## Credit

Found by Gemini (Google) in a multi-AI security review (Gemini R1, finding VULN-001). Reviewed independently by Claude Opus and Codex, who examined the same files in the same round but did not flag this specific path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced receiver robustness to prevent crashes when processing malformed syslog messages and invalid timestamps.
  * Implemented automatic exception tracking with rate-limited warnings for parsing failures to help identify problematic sources.
  * Improved timestamp parsing to gracefully handle invalid or out-of-range date/time components without failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmasarweh/UniFi-Insights-Plus/pull/111)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->