### PR TITLE
fix(unifi): use v2 firewall policy endpoint for logging toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Fix Firewall Syslog Manager policy toggles on UniFi Network 10.x by keeping
+  firewall policies and firewall zones in the same Network v2 identifier
+  namespace. This restores the zone matrix and prevents PATCH requests from
+  using synthesized policy ids when UniFi's Integration API omits policy ids or
+  returns zone UUIDs that cannot be joined to v2 policy zone ids.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - **Docker** and **Docker Compose**
 - **UniFi Router** (or any UniFi gateway that supports remote syslog)
 - **Zone-based firewall** (not legacy/classic). The Firewall Syslog Manager and firewall policy API require the zone-based policy engine. If you are still on the legacy/classic firewall, migrate via **Settings > Policy Engine** in your UniFi controller before setting up ULI.
+- **UniFi OS for Firewall Syslog Manager writes.** Firewall policy logging toggles use UniFi Network's local v2 firewall policy endpoints so UI-created policies and zone IDs stay addressable. Self-hosted controllers remain supported for discovery, but firewall management is disabled because those v2 endpoints are not available there.
 - **MaxMind GeoLite2 account** ([free signup](https://www.maxmind.com/en/geolite2/signup)) - for GeoIP/ASN lookups
 - **AbuseIPDB API key** ([free tier](https://www.abuseipdb.com/register?plan=free), recommended but optional) - for threat scoring
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | **UniFi Integration** | Network discovery, device name resolution, and firewall syslog management via **UniFi OS** (API key) or **self-hosted controllers** (username/password) |
 | **Pi-hole Integration** | DNS query logging via Pi-hole v6+ API |
 | **AdGuard Home** | DNS query logging support (coming soon) |
-| **Firewall Syslog Manager** | Zone matrix with bulk toggle — enable syslog on firewall rules without leaving the app (UniFi OS) |
+| **Firewall Syslog Manager** | Zone matrix with bulk toggle — enable syslog on firewall rules without leaving the app, including rules created in the UniFi Network UI (UniFi OS) |
 | **AI Agent Integration** *(MCP)* | Connect Claude Desktop, Claude Code, Gemini CLI (or any http mcp client) via the [Model Context Protocol (MCP)](https://insightsplus.dev/docs) to query your network data & setup through natural conversation |
 | **Device Names** | Friendly names from UniFi clients/devices with historical backfill |
 | **Theming & Preferences** | Dark/light theme, country display format, IP subline (show ASN beneath IPs) |

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -316,7 +316,7 @@ flowchart LR
         end
 
         subgraph FW_API["Firewall Queries"]
-            FW1["/api/firewall/policies<br>UniFi API passthrough<br>zones + policies"]
+            FW1["/api/firewall/policies<br>Network v2 policies + zones<br>Integration-shaped response"]
             FW2["/api/firewall/policies/bulk-logging<br>Batch toggle loggingEnabled"]
             FW3["/api/firewall/policies/match-log<br>Match log to policy"]
         end
@@ -349,3 +349,27 @@ flowchart LR
     style UI fill:#4a90d9,color:#fff
     style PATTERNS fill:#95a5a6,color:#fff
 ```
+
+## 8. UniFi Firewall API Boundary
+
+Most UniFi data access uses the documented local Network Integration API under
+`/proxy/network/integration/v1`. Firewall policy logging is intentionally
+different on UniFi OS controllers running Network 10.x:
+
+- Integration firewall policy reads can omit `id` for policies created in the
+  UniFi Network UI, which makes later PATCH calls impossible.
+- Integration firewall zone reads return UUID zone ids, while Network v2
+  firewall policies reference Mongo-style zone ids.
+- The Firewall Syslog Manager therefore reads both policies and zones from
+  Network v2 endpoints and reshapes them to the existing frontend contract.
+
+The invariant is that one `/api/firewall/policies` response must use one
+identifier namespace: every `policy.source.zoneId` and
+`policy.destination.zoneId` must appear in `zones[].id`. Policy writes use the
+same v2 `_id` exposed as `policy.id`, fetch the full policy body, flip only the
+`logging` flag, and `PUT` the full body back to Network v2.
+
+Log-to-policy matching still needs interface membership. When v2 zone records do
+not include contained `networkIds`, the matcher uses `firewall_zone_id` from the
+classic `/rest/networkconf` network records to join bridge interfaces to the same
+v2 zone ids.

--- a/issues/firewall-policy-v2-endpoint-fix.md
+++ b/issues/firewall-policy-v2-endpoint-fix.md
@@ -1,0 +1,414 @@
+# UniFi-Insights-Plus — Firewall policy toggle: switch to v2 internal API
+
+**Repo:** https://github.com/jmasarweh/UniFi-Insights-Plus
+**Observed against:** image revision `b4617fdc4e5164042c35f5132fa4e46b25e6ebd7` (3.7.0), controller UniFi Network 10.3.58, UDM Pro Gen1
+**Scope:** Fix the silent-400-on-toggle bug for UI-created firewall policies. Read- and write-path change in `unifi_api.py`; no frontend or DB changes required.
+
+---
+
+## 1. Problem statement
+
+UIP currently uses the UniFi **integration API** (`/proxy/network/integration/v1/sites/{site}/firewall/policies`) for both reads and writes of firewall policies. That API has a structural limitation in controller 10.x: it only exposes the `id` field on policies that were *created via the integration API itself*. Policies created via the UniFi Network web UI appear in the same response list but **carry no `id`**, so any subsequent PATCH-by-id silently constructs the URL `/firewall/policies/undefined` and the controller correctly returns HTTP 400.
+
+The user-visible symptom is: clicking the "enable logging" toggle on certain firewall policies in UIP does nothing, with no UI feedback. The backend logs the exception:
+
+```
+api.unifi  ERROR  Failed to patch firewall policy undefined
+  ...
+  requests.exceptions.HTTPError: 400 Client Error:  for url:
+    https://<udm>/proxy/network/integration/v1/sites/<uuid>/firewall/policies/undefined
+```
+
+On the affected deployment, **20 of 89** policies are affected — all of them USER_DEFINED rules created via the Network web UI.
+
+---
+
+## 2. Empirical findings (please re-verify on the target deployment before coding)
+
+Run the following against the live UDM (replace `${UDM_HOST}`, `${API_KEY}`, `${SITE_UUID}` with deployment values). Authentication is via the same `X-API-KEY` header UIP already uses.
+
+| Endpoint | Behavior |
+|---|---|
+| `GET /proxy/network/integration/v1/sites/{uuid}/firewall/policies?limit=200` | Returns 89 entries; `id` populated for 69, missing on 20 (all USER_DEFINED) |
+| `GET /proxy/network/v2/api/site/default/firewall-policies` | Returns 89 entries; `_id` populated on **all 89** (Mongo ObjectId, 24-char hex) |
+| `PATCH /proxy/network/integration/v1/sites/{uuid}/firewall/policies/{id}` with `{loggingEnabled: bool}` | Works for the 69 policies that have integration `id`; impossible for the other 20 |
+| `PUT /proxy/network/v2/api/site/default/firewall-policies/{_id}` with **full policy body** (just flip `logging`) | Works for **all 89**, returns 200 with the updated record |
+| `PUT /proxy/network/v2/api/site/default/firewall-policies/batch` with `[{_id, logging}]` | Returns 200 but **does not write anything**. **Do not use.** |
+| `PUT /proxy/network/v2/api/site/default/firewall-policies/{_id}` with partial body (just `{logging: bool}`) | Returns 400 ("Validation failed for argument [2]"). Full body is required. |
+
+The v2 `_id` and integration `id` are different identifier systems (Mongo ObjectId vs UUID); the same physical policy has both for API-created policies, only `_id` for UI-created ones. We searched all v2 records for the integration UUID of a known API-created policy and found it nowhere in the v2 schema — the mapping is held in an internal table we have no documented write path to.
+
+---
+
+## 3. Recommended fix
+
+Switch UIP from the integration API to the v2 internal API for **firewall policy reads and writes**. Keep using the integration API for everything else (sites discovery, devices, clients, etc.) — it works fine for those.
+
+The fix lives entirely in `unifi_api.py` in the running image (`/app/unifi_api.py`). Three functions to change, one new helper. The backend should re-shape the v2 response so that the existing frontend continues to work without changes.
+
+### 3.1 New v2 GET (replace `get_firewall_policies`)
+
+The current implementation paginates `/proxy/network/integration/v1/.../firewall/policies?offset=&limit=`. The v2 endpoint does **not** require pagination params on a typical deployment (returns all rows in one response), but you may add `?offset=&limit=` if you want to keep symmetry.
+
+Pseudocode:
+
+```python
+def get_firewall_policies(self) -> list:
+    """Return firewall policies from the v2 internal endpoint.
+
+    The integration API at /v1 only exposes `id` for policies that were
+    created via that API; UI-created policies arrive without an addressable
+    handle, which breaks PATCH. The v2 internal API at /v2/api/site/.../
+    firewall-policies returns `_id` for every policy. We re-shape the v2
+    schema to look like the integration schema so existing callers and the
+    frontend keep working without changes.
+    """
+    url = f"{self.host}/proxy/network/v2/api/site/default/firewall-policies"
+    resp = self._get_session().get(url, timeout=self.TIMEOUT)
+    self._check_integration_permissions(resp)
+    resp.raise_for_status()
+    v2_items = resp.json()
+    return [self._v2_policy_to_integration_shape(p) for p in v2_items]
+```
+
+Note: the URL uses the literal string `default` for the site (not the integration site UUID). All probes against this deployment used `default`. Verify on your test deployment.
+
+### 3.2 New v2 PATCH (replace `patch_firewall_policy`)
+
+```python
+def patch_firewall_policy(self, policy_id: str, logging_enabled: bool) -> dict:
+    """Update a single policy's logging via v2 endpoint.
+
+    `policy_id` here is the v2 `_id` (Mongo ObjectId, 24-char hex). We
+    fetch the full v2 record, flip `logging`, and PUT the full body —
+    v2 rejects partial updates ('Validation failed for argument [2]') and
+    the v2 'batch' endpoint silently no-ops, so neither is viable.
+    """
+    base = f"{self.host}/proxy/network/v2/api/site/default/firewall-policies"
+    # Fetch full body (v2 requires it for the write)
+    listing = self._get_session().get(base, timeout=self.TIMEOUT)
+    self._check_integration_permissions(listing)
+    listing.raise_for_status()
+    items = listing.json()
+    record = next((p for p in items if p["_id"] == policy_id), None)
+    if record is None:
+        raise ValueError(f"policy not found: {policy_id}")
+    if record.get("logging") == logging_enabled:
+        return self._v2_policy_to_integration_shape(record)  # no-op
+    record["logging"] = logging_enabled
+    resp = self._get_session().put(f"{base}/{policy_id}", json=record, timeout=self.TIMEOUT)
+    self._check_integration_permissions(resp)
+    resp.raise_for_status()
+    return self._v2_policy_to_integration_shape(resp.json())
+```
+
+Performance note: the GET-then-PUT is one extra HTTP round-trip per toggle. If that matters in the bulk path, cache the listing for the duration of one `bulk_patch_logging` invocation and pass each record into `_patch_one_policy` from that cache.
+
+### 3.3 New helper `_v2_policy_to_integration_shape`
+
+Translate v2 schema → integration schema so existing callers (and the frontend) don't see the change. Below is the mapping derived from real records on the test deployment:
+
+| Integration field | Source from v2 |
+|---|---|
+| `id` | `_id` |
+| `enabled` | `enabled` |
+| `name` | `name` |
+| `description` | `description` (or `""` if absent) |
+| `index` | `index` |
+| `loggingEnabled` | `logging` |
+| `action.type` | `action` (string → wrap as `{"type": <action>}`) |
+| `action.allowReturnTraffic` | `create_allow_respond` *only when action == "ALLOW"* |
+| `ipProtocolScope.ipVersion` | `ip_version` mapped: `"BOTH"`→`"IPV4_AND_IPV6"`, `"IPV4"`→`"IPV4"`, `"IPV6"`→`"IPV6"` |
+| `source.zoneId` | `source.zone_id` |
+| `destination.zoneId` | `destination.zone_id` |
+| `metadata.origin` | `"SYSTEM_DEFINED"` if `predefined` is true, else `"USER_DEFINED"` |
+| `source.trafficFilter` / `destination.trafficFilter` | see below — depends on `matching_target` |
+
+`trafficFilter` translation (apply to both `source` and `destination`):
+
+```
+v2 matching_target          →  integration trafficFilter
+─────────────────────────────────────────────────────────
+"ANY"                       →  (omit trafficFilter entirely)
+"APP"                       →  {type: "APPLICATION", applicationFilter: {applicationIds: <app_ids>}}
+"IP"                        →  {type: "IP_ADDRESS",
+                                  ipAddressFilter: {
+                                    type: "IP_ADDRESSES",
+                                    matchOpposite: <match_opposite_ips>,
+                                    items: [{type: "IP_ADDRESS", value: x} for x in ips]
+                                  }}
+"NETWORK"                   →  {type: "NETWORK",
+                                  networkFilter: {
+                                    networkIds: <network_ids>,
+                                    matchOpposite: <match_opposite_networks>
+                                  }}
+```
+
+If you see additional `matching_target` values on the target deployment, surface them honestly to the caller (raise or return an unknown-shape marker) rather than silently dropping fields — better to fail loudly than corrupt downstream comparisons.
+
+**Heads-up on inner IDs.** The id-system divergence applies not only to policies (integration UUID vs v2 `_id`) but also to **networks**, and possibly to other referenced objects (zones, applications). The same network appears as a UUID in `networkFilter.networkIds` from the integration API and as a Mongo `_id` in `network_ids` from v2. The translator above passes these through verbatim, which means:
+
+- **For the toggle-logging path, this does not matter** — UIP only writes back to the policy by its top-level id, and only changes the `logging` flag.
+- **For any feature that reads inner ids to display a name** (e.g. resolving `networkIds[0]` to "IoT VLAN"), the frontend would now receive v2-style ids. If UIP currently joins those against the integration-API networks endpoint, it would fail to find a match. Worth grepping for `networkIds` / `applicationIds` / `ipAddressFilter` consumers in the frontend before merging; if any exist, they need a corresponding v2 lookup or a backend join.
+
+Zones (`zoneId` → `zone_id`) appear to use Mongo `_id`s in both schemas on this deployment, but verify on yours.
+
+The reverse mapping (integration → v2) is not needed for this fix because we only call v2 with bodies we already obtained from v2.
+
+### 3.4 Update `bulk_patch_logging`
+
+Currently iterates `_patch_one_policy(item['id'], item['loggingEnabled'])` in 4 worker threads. After the change above, `_patch_one_policy` will call `patch_firewall_policy` which already does the GET-then-PUT. Optimization: pull the listing once at the top of `bulk_patch_logging` and pass each pre-fetched record down through the worker so per-policy traffic is one PUT instead of GET+PUT. Optional; correctness doesn't depend on it.
+
+### 3.5 Frontend
+
+**No changes required.** The frontend continues to do `PATCH /api/firewall/policies/${policy.id}` with `{loggingEnabled: bool}`. Because the backend now presents the v2 `_id` as `id` in its response, every policy carries a usable id from the frontend's perspective.
+
+If you want to be defensive against future API drift (recommended): in the row render where the toggle is wired, add `if (!policy.id) return;` so any future regression fails closed instead of producing silent 400s.
+
+---
+
+## 4. Out of scope (intentional)
+
+- **The "undefined" path produced by the bug today.** It vanishes the moment every policy carries an id.
+- **The 20 already-id-less policies on existing deployments.** They become addressable as soon as the backend reads them from v2; no migration, no data change, no operator action needed.
+- **Removing the integration API entirely.** It's still the right interface for the rest of UIP's surface (clients, devices, gateway info). Only firewall policy GET/PATCH switches.
+- **A general v2 client.** Don't refactor — this is two functions and a translator. A larger v2 abstraction can come later if you switch more endpoints.
+
+---
+
+## 5. Acceptance criteria
+
+The fix is complete when:
+
+1. `get_firewall_policies()` returns objects shaped exactly like the current integration-API output (same field names, same nesting), with `id` populated on **every** returned policy.
+2. `patch_firewall_policy(policy_id, logging_enabled)` succeeds against any policy in the controller, including those that were id-less before, and the change is observable in subsequent GET calls.
+3. The frontend "enable/disable logging" toggle works for **all** policies, including the ones that previously produced `api.unifi ERROR: Failed to patch firewall policy undefined`.
+4. `bulk_patch_logging` succeeds for a mixed list of API-created and UI-created policies. Verification pass still passes.
+5. No new dependency added, no schema change in Postgres, no env var change.
+
+---
+
+## 6. Tests
+
+Add to whatever test layer the repo already uses (`pytest.ini` is present in `/app/` so there is one).
+
+### 6.1 Pure-function test of the schema translator
+
+For each v2 → integration mapping case, feed a representative v2 record into `_v2_policy_to_integration_shape` and assert the output structure matches a hand-written expected integration shape. Cover:
+
+- `matching_target: "ANY"` → no `trafficFilter`
+- `matching_target: "APP"` with `app_ids` → `APPLICATION` filter
+- `matching_target: "IP"` with `ips` → `IP_ADDRESS` filter
+- `matching_target: "NETWORK"` with `network_ids` → `NETWORK` filter
+- `predefined: true` → `metadata.origin == "SYSTEM_DEFINED"`
+- `action: "ALLOW"` with `create_allow_respond: true` → `action.allowReturnTraffic: true`
+- `ip_version: "BOTH"` → `ipProtocolScope.ipVersion: "IPV4_AND_IPV6"`
+
+Real v2 records to base test fixtures on are reproducible via the GET probe above.
+
+### 6.2 Integration test against a live controller
+
+Marked optional / skipped by default. Pulls policies via the new path, asserts every returned record has a non-empty `id` field, picks one record with the lowest impact (e.g. by `predefined` flag and rule `index`), toggles `loggingEnabled`, asserts the toggle takes, restores the original value. Skip when `UNIFI_API_KEY` is not in env.
+
+### 6.3 Manual smoke test (the operator runs this)
+
+1. Open UIP firewall policies view.
+2. Toggle logging on one previously-broken policy (e.g. a NETWORK-filter policy created via the Network web UI).
+3. Verify the toggle persists (refresh page, check state).
+4. Verify in the UniFi Network UI that the policy's logging flag changed correspondingly.
+5. Toggle it back. Verify likewise.
+
+---
+
+## 7. Notes / hand-off context
+
+- The v2 endpoint accepts the same `X-API-KEY` header UIP already uses; no separate session/cookie auth needed on this controller version.
+- The v2 endpoint's URL uses the literal site name `default` (not the integration site UUID). Verify on any non-default-site deployments.
+- v2 `_id` is a 24-char lowercase hex string (Mongo ObjectId). The integration `id` is a UUID. Don't try to alias them; they are different identifier systems and the controller doesn't cross-reference them in any field we can read.
+- The integration API still works correctly for the policies that have integration `id`s — this fix doesn't break anything that was working; it adds working coverage for the missing 20-of-89.
+- We deliberately do **not** propose attempting to retroactively mint integration `id`s for UI-created policies (would require SSH into UDM and writing to an internal mapping table — unsupported, brittle across controller upgrades).
+- The integration API's POST-to-create-new-policy flow still works fine and could be useful for other features; nothing in this fix touches it.
+
+---
+
+## 8. Suggested PR shape
+
+Single PR:
+
+- `unifi_api.py` — replace `get_firewall_policies` and `patch_firewall_policy`, add `_v2_policy_to_integration_shape`. Optionally optimize `bulk_patch_logging`.
+- `tests/test_v2_policy_translation.py` (new) — pure-function tests per §6.1.
+- `README.md` / changelog entry — note: "Firewall policy toggle now works for policies created via the UniFi Network web UI, not just those created via the integration API." Brief mention that the underlying cause is a UniFi controller integration-API limitation.
+- No frontend changes.
+
+---
+
+## Addendum (2026-05-15): zones must also come from v2
+
+After deploying the initial fix we found that the **zone matrix in the Firewall Policies view is empty**, and toggling logging on some rows produces 404s on URLs like `/firewall-policies/<src_zone_id><dst_zone_id>3<counter>`. Root cause: the inner-id divergence applies to **zones**, contrary to my speculation in §3.3.
+
+Empirical comparison on the test deployment:
+
+| Zone name | v2 `_id` (from `firewall/zone-matrix`) | Integration `id` (from `firewall/zones`) |
+|---|---|---|
+| Internal | `6a02f3f867050d3ccb3cb0d3` | `fedb7e64-ff34-4dcb-ae6d-9645807b3329` |
+| Vpn | `6a02f3f867050d3ccb3cb0d6` | `31cd7a3a-45d0-40ae-9a7e-a073dd068305` |
+| Hotspot | `6a02f3f867050d3ccb3cb0d7` | `f3509485-b5d2-42d6-a9ce-838f21302082` |
+
+After the first patch, `get_firewall_policies()` returns policies whose `source.zoneId` / `destination.zoneId` are Mongo `_id`s (`6a02f3…`), while `get_firewall_zones()` is still hitting the integration API and returning zones with UUID `id`s (`fedb7e…`). The frontend can't cross-reference them, the zone-matrix renders empty, and on duplicate-name rows the frontend falls back to building synthetic keys from `source.zone_id + destination.zone_id + counter` — those synthetic keys are then sent back as policy IDs on PATCH, producing the observed 404s.
+
+### Fix
+
+In `unifi_api.py`:
+
+1. Add a helper for the v2 zone endpoint, parallel to `_firewall_policies_v2_url`:
+
+```python
+def _firewall_zones_v2_url(self) -> str:
+    """Return the v2 firewall zone-matrix URL for this controller."""
+    if self._controller_type == 'self_hosted':
+        raise NotImplementedError("Firewall zone v2 API not available on self-hosted controllers")
+    site = self.site or 'default'
+    return f"{self.host}/proxy/network/v2/api/site/{site}/firewall/zone-matrix"
+```
+
+2. Replace `get_firewall_zones()` to read from v2 and reshape into the integration zone schema the frontend already consumes:
+
+```python
+def get_firewall_zones(self) -> list:
+    """Fetch firewall zones from the v2 zone-matrix endpoint.
+
+    Reading zones from v2 keeps the zone identifier system consistent with
+    the policy identifier system. If zones came from the integration API
+    (UUIDs) while policies came from v2 (Mongo _ids), the frontend can't
+    cross-reference them — the zone matrix renders empty and duplicate-name
+    policy rows pick up synthesized keys that then fail PATCH with 404.
+    """
+    resp = self._get_session().get(self._firewall_zones_v2_url(), timeout=self.TIMEOUT)
+    self._check_integration_permissions(resp)
+    resp.raise_for_status()
+    return [self._v2_zone_to_integration_shape(z) for z in self._unwrap_v2_list(resp.json())]
+
+@staticmethod
+def _v2_zone_to_integration_shape(zone: dict) -> dict:
+    """Translate a v2 zone-matrix record to the integration zone shape.
+
+    The v2 record carries cross-zone aggregation info under `data` that the
+    integration shape doesn't carry; we drop it. The integration shape's
+    `networkIds` (zone → contained networks) isn't surfaced by v2 either;
+    we return [] which the existing frontend tolerates. `zone_key` ('internal',
+    'external', etc.) is exposed as `metadata.origin` proxy: zones with a
+    `zone_key` are predefined system zones, user-defined zones don't carry one.
+    """
+    return {
+        'id': zone.get('_id'),
+        'name': zone.get('name'),
+        'networkIds': [],
+        'metadata': {
+            'origin': 'SYSTEM_DEFINED' if zone.get('zone_key') else 'USER_DEFINED',
+            'configurable': True,
+        },
+    }
+```
+
+### Verification
+
+Run from inside the container after the fix:
+
+```python
+from deps import unifi_api
+data = unifi_api.get_firewall_data()
+zone_ids = {z['id'] for z in data['zones']}
+for p in data['policies']:
+    src = p['source']['zoneId']
+    dst = p['destination']['zoneId']
+    assert src in zone_ids, f"policy {p['name']!r} src zone {src} not in zones list"
+    assert dst in zone_ids, f"policy {p['name']!r} dst zone {dst} not in zones list"
+print("all policy zones resolve to a known zone — frontend can cross-reference")
+```
+
+### Acceptance criteria addendum
+
+5. Every `policy.source.zoneId` and `policy.destination.zoneId` returned by `get_firewall_data()` must appear as an `id` in the `zones` list of the same response.
+6. The zone matrix on the Firewall Policies page renders populated, with per-cell policy counts visible.
+7. Toggling logging on a previously-broken policy (e.g. `DropInvalid`, `EstablishedRelated`, `Allow smartmeter`) succeeds with the new v2 PATCH path, no longer producing 404s on synthesized URLs.
+
+---
+
+## Addendum (2026-05-22): final API boundary and implementation approach
+
+### Documentation research summary
+
+Ubiquiti's official API guidance separates two supported surfaces:
+
+- **Site Manager API** at `api.ui.com`, for cloud-level aggregated site/device status.
+- **Local Application APIs**, where each UniFi application exposes local,
+  application-specific endpoints. For Network, Ubiquiti directs operators to
+  the controller's own **UniFi Network > Integrations** page for version-specific
+  API docs.
+
+Sources:
+
+- Ubiquiti Help Center: [Getting Started with the Official UniFi API](https://help.ui.com/hc/en-us/articles/30076656117655-Getting-Started-with-the-Official-UniFi-API)
+- Local Network API docs observed for Network 10.0.162, e.g. [Get Firewall Zones](https://developer.ui.com/network/v10.0.162/getfirewallzones)
+- Ubiquiti Help Center: [Zone-Based Firewalls in UniFi](https://help.ui.com/hc/en-us/articles/115003173168-Zone-Based-Firewalls-in-UniFi), which notes that extra policies can be created by features such as port forwarding and VPN servers.
+
+The documented Network Integration API is the right default for stable, public
+resources. It is not sufficient for UIP's firewall logging toggle in Network
+10.x because real deployments show that:
+
+- `GET /proxy/network/integration/v1/sites/{site_uuid}/firewall/policies`
+  can omit `id` on policies created in the UniFi Network UI.
+- `GET /proxy/network/integration/v1/sites/{site_uuid}/firewall/zones`
+  returns zone UUIDs that do not match the zone ids embedded in v2 policy
+  records.
+- `GET /proxy/network/v2/api/site/{site}/firewall-policies` and
+  `GET /proxy/network/v2/api/site/{site}/firewall/zone-matrix` use the same
+  Mongo-style zone id namespace.
+
+So the refactor is intentionally narrow: keep the Integration API for normal
+site discovery and non-firewall resources, but keep the Firewall Syslog Manager's
+policy and zone view entirely inside the Network v2 identifier namespace.
+
+### Implemented approach
+
+1. `get_firewall_policies()` reads v2 firewall policy records and reshapes them
+   to the existing frontend policy schema. Top-level `id` is the v2 `_id`.
+2. `patch_firewall_policy()` writes through v2 by fetching the full policy body,
+   flipping only `logging`, and `PUT`ing the full body to
+   `/firewall-policies/{_id}`. Partial writes and the v2 batch endpoint remain
+   intentionally avoided because they were observed to fail or no-op.
+3. `get_firewall_zones()` now reads
+   `/proxy/network/v2/api/site/{site}/firewall/zone-matrix` and reshapes zones
+   to the frontend's existing zone schema. Zone `id` is the v2 `_id`, so every
+   `policy.source.zoneId` and `policy.destination.zoneId` can resolve in the
+   same response.
+4. `get_network_config()` carries `firewall_zone_id` from classic
+   `/rest/networkconf` into each network record. This preserves log-to-policy
+   matching when v2 zone records omit `networkIds`; the matcher can still join
+   `network.firewall_zone_id` to the v2 zone id.
+5. `isControllablePolicy()` rejects rows without `policy.id` before the frontend
+   can send a PATCH. This is a guardrail, not the primary fix.
+
+### Design rule
+
+Do not mix Integration API UUIDs and v2 Mongo ids inside one firewall policy
+response. If future firewall-policy features need additional policy-adjacent
+objects (applications, networks, port-forward-generated policies, etc.), either:
+
+- fetch those objects from the same v2 surface, or
+- translate them explicitly before exposing them to the frontend.
+
+Implicit joins by display name or synthetic ids are not acceptable for write
+paths. They caused the observed `/firewall-policies/<src><dst><counter>` 404s.
+
+### Verification after implementation
+
+- Unit tests cover v2 policy translation, v2 zone translation, same-response
+  policy/zone id consistency, matcher fallback through `firewall_zone_id`, and
+  frontend refusal to toggle policies without ids.
+- Full receiver suite: `689 passed, 1 skipped`.
+- Targeted UI helper test: `3 passed`.
+- Full UI suite has an unrelated pre-existing failure in
+  `App.vpn-toast-dismissal.test.jsx`: the test mock replaces `localStorage`
+  without `getItem`, causing `App.jsx` theme initialization to fail before this
+  firewall code is exercised.

--- a/receiver/firewall_policy_matcher.py
+++ b/receiver/firewall_policy_matcher.py
@@ -269,17 +269,24 @@ def build_zone_map(unifi_api, vpn_networks=None):
     zones = unifi_api.get_firewall_zones()
     net_config = unifi_api.get_network_config()
 
-    # Build network_id -> interface from get_network_config() networks
+    # Build network_id -> interface from get_network_config() networks. When the
+    # firewall policy view is backed by UniFi's v2 API, zones may not carry
+    # networkIds. Classic /rest/networkconf still exposes firewall_zone_id in the
+    # same v2 namespace, so keep a second index for that direct zone join.
     network_id_to_info = {}
+    zone_id_to_network_infos = {}
     for net in net_config.get('networks', []):
         nid = net.get('id')
-        if not nid:
-            continue
-        network_id_to_info[nid] = {
+        info = {
             'name': net.get('name', ''),
             'interface': net.get('interface'),
             'vlan': net.get('vlan'),
         }
+        if nid:
+            network_id_to_info[nid] = info
+        firewall_zone_id = net.get('firewall_zone_id')
+        if firewall_zone_id:
+            zone_id_to_network_infos.setdefault(firewall_zone_id, []).append(info)
 
     # WAN physical interfaces
     wan_interfaces = []
@@ -311,16 +318,30 @@ def build_zone_map(unifi_api, vpn_networks=None):
             custom_idx += 1
             chain = f'CUSTOM{custom_idx}'
 
-        # Resolve interfaces from networkIds
+        # Resolve interfaces from networkIds. If v2 zones omit networkIds, fall
+        # back to the direct network.firewall_zone_id mapping prepared above.
         interfaces = []
+        seen_interfaces = set()
+
+        def add_interface(info):
+            """Append one network interface once, preserving the existing shape."""
+            iface = info.get('interface')
+            if not iface or iface in seen_interfaces:
+                return
+            interfaces.append({
+                'interface': iface,
+                'network_name': info.get('name', ''),
+                'vlan': info.get('vlan'),
+            })
+            seen_interfaces.add(iface)
+
         for nid in z.get('networkIds', []):
             info = network_id_to_info.get(nid)
-            if info and info.get('interface'):
-                interfaces.append({
-                    'interface': info['interface'],
-                    'network_name': info['name'],
-                    'vlan': info.get('vlan'),
-                })
+            if info:
+                add_interface(info)
+
+        for info in zone_id_to_network_infos.get(zone_id, []):
+            add_interface(info)
 
         # External zone — add WAN interfaces
         if zname_lower == 'external' and not interfaces:

--- a/receiver/tests/test_firewall_policy_matcher.py
+++ b/receiver/tests/test_firewall_policy_matcher.py
@@ -347,6 +347,36 @@ class TestBuildZoneMap:
         # IDs don't match → zone gets no interfaces (silent degradation)
         assert result['zone_map'][0]['interfaces'] == []
 
+    def test_v2_zone_id_maps_interface_from_network_firewall_zone_id(self):
+        """v2 zones omit networkIds, so direct network→zone ids must be honored.
+
+        UniFi's v2 firewall policies reference v2 zone ids. When zones also come
+        from v2, the zone records may not carry Integration-style networkIds.
+        The classic networkconf record carries firewall_zone_id in the same v2
+        namespace, which lets log-policy matching still map br* interfaces to
+        the same zone ids returned by the policy endpoint.
+        """
+        api = _make_api(
+            zones=[_zone('zone-v2-internal', 'Internal')],
+            net_config={
+                'wan_interfaces': [],
+                'networks': [
+                    {
+                        'id': 'integration-network-id',
+                        'name': 'Default',
+                        'interface': 'br0',
+                        'vlan': 1,
+                        'firewall_zone_id': 'zone-v2-internal',
+                    },
+                ],
+            },
+        )
+
+        result = fpm.build_zone_map(api)
+
+        assert result['zone_map'][0]['zone_id'] == 'zone-v2-internal'
+        assert result['zone_map'][0]['interfaces'][0]['interface'] == 'br0'
+
 
 # ── match_log_to_policy ──────────────────────────────────────────────────────
 

--- a/receiver/tests/test_v2_policy_translation.py
+++ b/receiver/tests/test_v2_policy_translation.py
@@ -1,0 +1,288 @@
+"""Tests for UniFi firewall policy v2 endpoint compatibility.
+
+The firewall syslog UI expects the Integration API policy schema, but UniFi
+Network 10.x omits Integration API ``id`` values for some policies created in
+the controller UI. These tests lock down the compatibility layer that reads and
+writes those policies through the internal v2 endpoint while preserving the
+existing shape consumed by the rest of the app.
+"""
+
+import os
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from unifi_api import UniFiAPI
+
+
+POLICY_ID = "65f31c0a1234567890abcdef"
+
+
+def _response(json_body, status_code=200):
+    """Build a requests.Response-like mock with a stable JSON body."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    resp.text = ""
+    return resp
+
+
+def _base_v2_policy(**overrides):
+    """Return a representative v2 firewall policy record for translator tests."""
+    policy = {
+        "_id": POLICY_ID,
+        "enabled": True,
+        "name": "Allow IoT telemetry",
+        "description": "",
+        "index": 1200,
+        "logging": False,
+        "action": "ALLOW",
+        "create_allow_respond": True,
+        "ip_version": "BOTH",
+        "predefined": False,
+        "source": {
+            "zone_id": "zone-internal",
+            "matching_target": "ANY",
+        },
+        "destination": {
+            "zone_id": "zone-external",
+            "matching_target": "ANY",
+        },
+    }
+    for key, value in overrides.items():
+        if key in ("source", "destination"):
+            policy[key].update(value)
+        else:
+            policy[key] = value
+    return policy
+
+
+@pytest.fixture
+def api():
+    """Create a UniFiAPI instance whose HTTP session is fully mocked."""
+    mock_db = MagicMock()
+    mock_db.get_config = MagicMock(return_value=None)
+    with patch.object(UniFiAPI, "_resolve_config"):
+        uapi = UniFiAPI(mock_db)
+    uapi.host = "https://fake-controller"
+    uapi.site = "default"
+    uapi.api_key = "test-key"
+    uapi.enabled = True
+    uapi._controller_type = "unifi_os"
+    uapi._session = MagicMock()
+    return uapi
+
+
+class TestV2PolicyTranslation:
+    def test_any_target_preserves_existing_integration_shape(self, api):
+        """ANY matching omits trafficFilter and exposes every policy with id."""
+        mapped = api._v2_policy_to_integration_shape(_base_v2_policy())
+
+        assert mapped == {
+            "id": POLICY_ID,
+            "enabled": True,
+            "name": "Allow IoT telemetry",
+            "description": "",
+            "index": 1200,
+            "loggingEnabled": False,
+            "action": {
+                "type": "ALLOW",
+                "allowReturnTraffic": True,
+            },
+            "ipProtocolScope": {
+                "ipVersion": "IPV4_AND_IPV6",
+            },
+            "source": {
+                "zoneId": "zone-internal",
+            },
+            "destination": {
+                "zoneId": "zone-external",
+            },
+            "metadata": {
+                "origin": "USER_DEFINED",
+            },
+        }
+
+    def test_app_target_maps_to_application_filter(self, api):
+        """APP matching carries v2 app_ids into applicationFilter."""
+        mapped = api._v2_policy_to_integration_shape(_base_v2_policy(
+            source={
+                "matching_target": "APP",
+                "app_ids": ["app-a", "app-b"],
+            },
+        ))
+
+        assert mapped["source"]["trafficFilter"] == {
+            "type": "APPLICATION",
+            "applicationFilter": {
+                "applicationIds": ["app-a", "app-b"],
+            },
+        }
+
+    def test_ip_target_maps_to_ip_address_filter(self, api):
+        """IP matching expands each address into Integration API item objects."""
+        mapped = api._v2_policy_to_integration_shape(_base_v2_policy(
+            destination={
+                "matching_target": "IP",
+                "ips": ["192.0.2.10", "2001:db8::10"],
+                "match_opposite_ips": True,
+            },
+        ))
+
+        assert mapped["destination"]["trafficFilter"] == {
+            "type": "IP_ADDRESS",
+            "ipAddressFilter": {
+                "type": "IP_ADDRESSES",
+                "matchOpposite": True,
+                "items": [
+                    {"type": "IP_ADDRESS", "value": "192.0.2.10"},
+                    {"type": "IP_ADDRESS", "value": "2001:db8::10"},
+                ],
+            },
+        }
+
+    def test_network_target_maps_to_network_filter(self, api):
+        """NETWORK matching preserves v2 network IDs for logging toggles."""
+        mapped = api._v2_policy_to_integration_shape(_base_v2_policy(
+            source={
+                "matching_target": "NETWORK",
+                "network_ids": ["net-mongo-a", "net-mongo-b"],
+                "match_opposite_networks": False,
+            },
+        ))
+
+        assert mapped["source"]["trafficFilter"] == {
+            "type": "NETWORK",
+            "networkFilter": {
+                "networkIds": ["net-mongo-a", "net-mongo-b"],
+                "matchOpposite": False,
+            },
+        }
+
+    def test_system_defined_policy_origin_and_ipv6_are_preserved(self, api):
+        """predefined and ip_version fields map to existing frontend names."""
+        mapped = api._v2_policy_to_integration_shape(_base_v2_policy(
+            predefined=True,
+            ip_version="IPV6",
+            action="BLOCK",
+            create_allow_respond=True,
+        ))
+
+        assert mapped["metadata"]["origin"] == "SYSTEM_DEFINED"
+        assert mapped["ipProtocolScope"]["ipVersion"] == "IPV6"
+        assert mapped["action"] == {"type": "BLOCK"}
+
+    def test_unknown_matching_target_fails_loudly(self, api):
+        """Unexpected v2 matching targets should not be silently dropped."""
+        with pytest.raises(ValueError, match="Unsupported v2 firewall policy matching_target"):
+            api._v2_policy_to_integration_shape(_base_v2_policy(
+                source={"matching_target": "REGION"},
+            ))
+
+
+class TestV2FirewallPolicyEndpoints:
+    def test_get_firewall_policies_reads_v2_endpoint_and_translates(self, api):
+        """Firewall policy reads use v2 so UI-created policies always have ids."""
+        api._session.get.return_value = _response([_base_v2_policy()])
+
+        policies = api.get_firewall_policies()
+
+        api._session.get.assert_called_once_with(
+            "https://fake-controller/proxy/network/v2/api/site/default/firewall-policies",
+            timeout=api.TIMEOUT,
+        )
+        assert policies[0]["id"] == POLICY_ID
+        assert policies[0]["loggingEnabled"] is False
+
+    def test_patch_firewall_policy_puts_full_v2_body(self, api):
+        """v2 rejects partial updates, so patch fetches and PUTs the full record."""
+        original = _base_v2_policy(logging=False)
+        updated = _base_v2_policy(logging=True)
+        api._session.get.return_value = _response([deepcopy(original)])
+        api._session.put.return_value = _response(updated)
+
+        result = api.patch_firewall_policy(POLICY_ID, True)
+
+        api._session.get.assert_called_once_with(
+            "https://fake-controller/proxy/network/v2/api/site/default/firewall-policies",
+            timeout=api.TIMEOUT,
+        )
+        api._session.put.assert_called_once()
+        put_url = api._session.put.call_args.args[0]
+        put_body = api._session.put.call_args.kwargs["json"]
+        assert put_url == (
+            "https://fake-controller/proxy/network/v2/api/site/default/"
+            f"firewall-policies/{POLICY_ID}"
+        )
+        assert put_body["_id"] == POLICY_ID
+        assert put_body["logging"] is True
+        assert set(original).issubset(set(put_body))
+        assert result["id"] == POLICY_ID
+        assert result["loggingEnabled"] is True
+
+    def test_patch_firewall_policy_skips_put_when_state_already_matches(self, api):
+        """A no-op logging change should return the translated record without PUT."""
+        api._session.get.return_value = _response([_base_v2_policy(logging=True)])
+
+        result = api.patch_firewall_policy(POLICY_ID, True)
+
+        api._session.put.assert_not_called()
+        assert result["id"] == POLICY_ID
+        assert result["loggingEnabled"] is True
+
+    def test_patch_firewall_policy_raises_when_policy_missing(self, api):
+        """Missing ids surface clearly instead of writing to an undefined URL."""
+        api._session.get.return_value = _response([_base_v2_policy()])
+
+        with pytest.raises(ValueError, match="policy not found"):
+            api.patch_firewall_policy("65f31c0a0000000000000000", True)
+
+        api._session.put.assert_not_called()
+
+
+def test_live_controller_v2_firewall_policy_toggle_round_trip():
+    """Optional live controller smoke test, skipped unless explicitly enabled.
+
+    Set UNIFI_LIVE_FIREWALL_TOGGLE=1 together with UNIFI_HOST and
+    UNIFI_API_KEY to run this against a real UniFi OS controller. The test picks
+    a user-defined policy when one exists, toggles logging, verifies the read
+    path observes the change, and restores the original logging value.
+    """
+    if os.environ.get("UNIFI_LIVE_FIREWALL_TOGGLE") != "1":
+        pytest.skip("set UNIFI_LIVE_FIREWALL_TOGGLE=1 to modify a live policy")
+    if not os.environ.get("UNIFI_HOST") or not os.environ.get("UNIFI_API_KEY"):
+        pytest.skip("UNIFI_HOST and UNIFI_API_KEY are required for live testing")
+
+    mock_db = MagicMock()
+    mock_db.get_config = MagicMock(return_value=None)
+    with patch.object(UniFiAPI, "_resolve_config"):
+        uapi = UniFiAPI(mock_db)
+    uapi.host = os.environ["UNIFI_HOST"].rstrip("/")
+    uapi.api_key = os.environ["UNIFI_API_KEY"]
+    uapi.site = os.environ.get("UNIFI_SITE", "default")
+    uapi.verify_ssl = os.environ.get("UNIFI_VERIFY_SSL", "").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+    policies = uapi.get_firewall_policies()
+    assert policies
+    assert all(policy.get("id") for policy in policies)
+
+    candidate = next(
+        (policy for policy in policies
+         if policy.get("metadata", {}).get("origin") == "USER_DEFINED"),
+        policies[0],
+    )
+    original_logging = candidate.get("loggingEnabled", False)
+    try:
+        updated = uapi.patch_firewall_policy(candidate["id"], not original_logging)
+        assert updated["loggingEnabled"] is (not original_logging)
+        reread = {policy["id"]: policy for policy in uapi.get_firewall_policies()}
+        assert reread[candidate["id"]]["loggingEnabled"] is (not original_logging)
+    finally:
+        uapi.patch_firewall_policy(candidate["id"], original_logging)

--- a/receiver/tests/test_v2_policy_translation.py
+++ b/receiver/tests/test_v2_policy_translation.py
@@ -242,6 +242,50 @@ class TestV2FirewallPolicyEndpoints:
 
         api._session.put.assert_not_called()
 
+    def test_bulk_patch_logging_prefetches_v2_listing_once_for_writes(self, api):
+        """Bulk logging should avoid one full v2 listing GET per policy."""
+        policy_1 = _base_v2_policy(
+            _id="65f31c0a1234567890abcde1",
+            name="Policy 1",
+            logging=False,
+        )
+        policy_2 = _base_v2_policy(
+            _id="65f31c0a1234567890abcde2",
+            name="Policy 2",
+            logging=False,
+        )
+        verified_1 = _base_v2_policy(
+            _id=policy_1["_id"],
+            name="Policy 1",
+            logging=True,
+        )
+        verified_2 = _base_v2_policy(
+            _id=policy_2["_id"],
+            name="Policy 2",
+            logging=True,
+        )
+        api._session.get.side_effect = [
+            _response([deepcopy(policy_1), deepcopy(policy_2)]),
+            _response([verified_1, verified_2]),
+            _response([verified_1, verified_2]),
+        ]
+
+        def put_policy(_url, json, timeout):
+            """Mirror the controller by returning the full policy body just PUT."""
+            return _response(dict(json))
+
+        api._session.put.side_effect = put_policy
+
+        result = api.bulk_patch_logging([
+            {"id": policy_1["_id"], "loggingEnabled": True},
+            {"id": policy_2["_id"], "loggingEnabled": True},
+        ])
+
+        assert result["success"] == 2
+        assert result["failed"] == 0
+        assert api._session.get.call_count == 2
+        assert api._session.put.call_count == 2
+
 
 def test_live_controller_v2_firewall_policy_toggle_round_trip():
     """Optional live controller smoke test, skipped unless explicitly enabled.

--- a/receiver/tests/test_v2_policy_translation.py
+++ b/receiver/tests/test_v2_policy_translation.py
@@ -60,6 +60,20 @@ def _base_v2_policy(**overrides):
     return policy
 
 
+def _base_v2_zone(**overrides):
+    """Return a representative v2 zone-matrix record for translator tests."""
+    zone = {
+        "_id": "6a02f3f867050d3ccb3cb0d3",
+        "name": "Internal",
+        "zone_key": "internal",
+        "data": {
+            "policy_count": 12,
+        },
+    }
+    zone.update(overrides)
+    return zone
+
+
 @pytest.fixture
 def api():
     """Create a UniFiAPI instance whose HTTP session is fully mocked."""
@@ -285,6 +299,56 @@ class TestV2FirewallPolicyEndpoints:
         assert result["failed"] == 0
         assert api._session.get.call_count == 2
         assert api._session.put.call_count == 2
+
+
+class TestV2FirewallZoneEndpoints:
+    def test_zone_translation_preserves_v2_id_for_policy_cross_reference(self, api):
+        """Zone ids must stay in the same v2 namespace as policy zone_id values."""
+        mapped = api._v2_zone_to_integration_shape(_base_v2_zone())
+
+        assert mapped == {
+            "id": "6a02f3f867050d3ccb3cb0d3",
+            "name": "Internal",
+            "networkIds": [],
+            "metadata": {
+                "origin": "SYSTEM_DEFINED",
+                "configurable": True,
+            },
+        }
+
+    def test_get_firewall_zones_reads_v2_zone_matrix_and_translates(self, api):
+        """Firewall zones must come from v2 so the matrix can resolve policy zones."""
+        api._session.get.return_value = _response([_base_v2_zone()])
+
+        zones = api.get_firewall_zones()
+
+        api._session.get.assert_called_once_with(
+            "https://fake-controller/proxy/network/v2/api/site/default/firewall/zone-matrix",
+            timeout=api.TIMEOUT,
+        )
+        assert zones[0]["id"] == "6a02f3f867050d3ccb3cb0d3"
+        assert zones[0]["name"] == "Internal"
+
+    def test_firewall_data_uses_one_zone_id_namespace(self, api):
+        """Every policy source/destination zone id must resolve in the zones list."""
+        policy = _base_v2_policy(
+            source={"zone_id": "zone-internal-v2"},
+            destination={"zone_id": "zone-external-v2"},
+        )
+        zones = [
+            _base_v2_zone(_id="zone-internal-v2", name="Internal"),
+            _base_v2_zone(_id="zone-external-v2", name="External", zone_key="external"),
+        ]
+        api._session.get.side_effect = [
+            _response([policy]),
+            _response(zones),
+        ]
+
+        data = api.get_firewall_data()
+
+        zone_ids = {zone["id"] for zone in data["zones"]}
+        assert data["policies"][0]["source"]["zoneId"] in zone_ids
+        assert data["policies"][0]["destination"]["zoneId"] in zone_ids
 
 
 def test_live_controller_v2_firewall_policy_toggle_round_trip():

--- a/receiver/unifi_api.py
+++ b/receiver/unifi_api.py
@@ -1,7 +1,8 @@
 """
 UniFi Log Insight - UniFi Controller API Client
 
-Handles all interactions with the UniFi Controller's Classic and Integration APIs.
+Handles interactions with UniFi Controller Classic, Integration, and selected
+internal v2 APIs.
 Phase 1: Settings, wizard network config, firewall policy management.
 Phase 2: Client/device polling, IP-to-device-name enrichment.
 """
@@ -641,12 +642,21 @@ class UniFiAPI:
             })
 
         # ── Network segments from Integration API (/networks) ──
-        # Subnet lookup from classic API /rest/networkconf (keyed by name)
+        # Subnet and firewall-zone lookup from classic API /rest/networkconf
+        # (keyed by name). The Integration API returns clean network UUIDs, but
+        # the v2 firewall policy/zone endpoints use Mongo-style zone ids. Keeping
+        # firewall_zone_id on each network gives the matcher a same-namespace
+        # bridge without changing the public setup-wizard fields.
         subnet_by_name = {}
+        firewall_zone_by_name = {}
         for net in networks_raw:
             n = net.get('name', '')
-            if n and net.get('ip_subnet'):
+            if not n:
+                continue
+            if net.get('ip_subnet'):
                 subnet_by_name[n] = net['ip_subnet']
+            if net.get('firewall_zone_id'):
+                firewall_zone_by_name[n] = net['firewall_zone_id']
 
         networks = []
         try:
@@ -666,6 +676,7 @@ class UniFiAPI:
                     'interface': iface,
                     'vlan': vlan_id,
                     'ip_subnet': subnet_by_name.get(name, ''),
+                    'firewall_zone_id': firewall_zone_by_name.get(name),
                 })
         except Exception as e:
             logger.warning("Integration API /networks failed, falling back to classic: %s", e)
@@ -685,6 +696,7 @@ class UniFiAPI:
                     'interface': iface,
                     'vlan': vlan_id,
                     'ip_subnet': net.get('ip_subnet', ''),
+                    'firewall_zone_id': net.get('firewall_zone_id'),
                 })
 
         return {
@@ -823,22 +835,50 @@ class UniFiAPI:
     # ── Phase 1: Firewall Management ─────────────────────────────────────────
 
     def get_firewall_zones(self) -> list:
-        """Fetch all firewall zones."""
-        data = self._get_integration_site('/firewall/zones')
-        return data.get('data', [])
+        """Fetch firewall zones from the v2 zone-matrix endpoint.
+
+        Firewall policies are read from UniFi's v2 policy endpoint because the
+        Integration API can omit policy ids for rules created in the Network UI.
+        The same identifier split exists for zones: v2 policy ``source.zone_id``
+        and ``destination.zone_id`` values are Mongo-style ids, while Integration
+        API zones expose UUIDs. Reading zones from v2 keeps the matrix and log
+        matcher in one identifier namespace.
+
+        The returned records are reshaped to the Integration-style schema the
+        frontend already consumes.
+        """
+        resp = self._get_session().get(
+            self._firewall_zones_v2_url(),
+            timeout=self.TIMEOUT,
+        )
+        self._check_integration_permissions(resp)
+        resp.raise_for_status()
+        zones = self._unwrap_v2_list(resp.json())
+        return [self._v2_zone_to_integration_shape(zone) for zone in zones]
 
     def _firewall_policies_v2_url(self) -> str:
         """Return the v2 firewall policy collection URL for this controller.
 
-        Firewall policies are the only UniFi resource currently read from the
-        internal v2 API. Keeping URL construction in one place prevents the
-        single-policy and bulk paths from drifting if UniFi requires a different
-        site reference in the future.
+        Keeping URL construction in one place prevents the read, single-policy,
+        and bulk paths from drifting if UniFi requires a different site reference
+        in the future.
         """
         if self._controller_type == 'self_hosted':
             raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
         site = self.site or 'default'
         return f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
+
+    def _firewall_zones_v2_url(self) -> str:
+        """Return the v2 firewall zone-matrix URL for this controller.
+
+        This endpoint is paired with ``/firewall-policies`` because both expose
+        v2 zone ids. The Integration API's ``/firewall/zones`` endpoint exposes a
+        different zone id space and cannot be joined to v2 policy records.
+        """
+        if self._controller_type == 'self_hosted':
+            raise NotImplementedError("Firewall zone v2 API not available on self-hosted controllers")
+        site = self.site or 'default'
+        return f"{self.host}/proxy/network/v2/api/site/{site}/firewall/zone-matrix"
 
     @staticmethod
     def _unwrap_v2_list(body) -> list:
@@ -853,7 +893,44 @@ class UniFiAPI:
             return body['data']
         if isinstance(body, list):
             return body
-        raise ValueError("Unexpected v2 firewall policy response shape")
+        raise ValueError("Unexpected v2 list response shape")
+
+    @staticmethod
+    def _v2_zone_to_integration_shape(zone: dict) -> dict:
+        """Translate a v2 zone-matrix record to the Integration API zone shape.
+
+        v2 zone-matrix records carry UI aggregation fields under keys such as
+        ``data``; those are not part of the existing UIP contract and are dropped.
+        Some controller versions do not expose contained network ids on this
+        endpoint. When they are absent, ``networkIds`` is returned as an empty
+        list and the log matcher falls back to ``network.firewall_zone_id`` from
+        classic ``/rest/networkconf`` to recover interface membership.
+        """
+
+        network_ids = zone.get('networkIds') or zone.get('network_ids') or []
+        if isinstance(network_ids, list):
+            network_ids = [
+                item.get('_id') or item.get('id') if isinstance(item, dict) else item
+                for item in network_ids
+            ]
+            network_ids = [item for item in network_ids if item]
+        else:
+            network_ids = []
+
+        metadata = zone.get('metadata') if isinstance(zone.get('metadata'), dict) else {}
+        origin = metadata.get('origin')
+        if not origin:
+            origin = 'SYSTEM_DEFINED' if zone.get('zone_key') or zone.get('predefined') else 'USER_DEFINED'
+
+        return {
+            'id': zone.get('_id') or zone.get('id'),
+            'name': zone.get('name') or zone.get('display_name') or '',
+            'networkIds': network_ids,
+            'metadata': {
+                'origin': origin,
+                'configurable': metadata.get('configurable', zone.get('configurable', True)),
+            },
+        }
 
     def _get_v2_firewall_policy_records(self) -> list:
         """Fetch raw v2 firewall policy records without schema translation.

--- a/receiver/unifi_api.py
+++ b/receiver/unifi_api.py
@@ -827,22 +827,141 @@ class UniFiAPI:
         data = self._get_integration_site('/firewall/zones')
         return data.get('data', [])
 
-    def get_firewall_policies(self) -> list:
-        """Fetch ALL firewall policies (handles pagination internally)."""
-        all_policies = []
-        offset = 0
-        limit = 50
-        while True:
-            data = self._get_integration_site(
-                f'/firewall/policies?offset={offset}&limit={limit}'
+    @staticmethod
+    def _v2_policy_to_integration_shape(policy: dict) -> dict:
+        """Translate a v2 firewall policy record to the Integration API shape.
+
+        UniFi Network 10.x exposes firewall policies through two different
+        schemas. The public Integration API shape is what this app and the
+        frontend already consume, but that API omits ``id`` for policies created
+        in the UniFi Network UI. The internal v2 endpoint includes a writable
+        Mongo ``_id`` for every policy. This translator deliberately presents
+        that v2 ``_id`` as Integration-style ``id`` so callers can keep using
+        the existing PATCH route without knowing which UniFi API backed it.
+
+        The mapping is intentionally narrow: it covers the fields UIP uses for
+        listing, matching, and toggling logging. If UniFi introduces a new
+        ``matching_target`` value, the helper raises instead of silently
+        dropping a filter and making downstream comparisons look valid when they
+        are incomplete.
+        """
+
+        def translate_side(side: dict | None, label: str) -> dict:
+            """Translate one endpoint side (source or destination).
+
+            v2 stores side-specific filters as a flat ``matching_target`` plus
+            target-specific lists. The Integration API nests those same values
+            under ``trafficFilter``. ``ANY`` is represented by omitting
+            ``trafficFilter`` entirely, which is the existing frontend contract.
+            """
+            side = side or {}
+            translated = {
+                'zoneId': side.get('zone_id'),
+            }
+            target = side.get('matching_target') or 'ANY'
+
+            if target == 'ANY':
+                return translated
+
+            if target == 'APP':
+                translated['trafficFilter'] = {
+                    'type': 'APPLICATION',
+                    'applicationFilter': {
+                        'applicationIds': side.get('app_ids') or [],
+                    },
+                }
+                return translated
+
+            if target == 'IP':
+                translated['trafficFilter'] = {
+                    'type': 'IP_ADDRESS',
+                    'ipAddressFilter': {
+                        'type': 'IP_ADDRESSES',
+                        'matchOpposite': bool(side.get('match_opposite_ips', False)),
+                        'items': [
+                            {'type': 'IP_ADDRESS', 'value': ip}
+                            for ip in (side.get('ips') or [])
+                        ],
+                    },
+                }
+                return translated
+
+            if target == 'NETWORK':
+                translated['trafficFilter'] = {
+                    'type': 'NETWORK',
+                    'networkFilter': {
+                        'networkIds': side.get('network_ids') or [],
+                        'matchOpposite': bool(side.get('match_opposite_networks', False)),
+                    },
+                }
+                return translated
+
+            raise ValueError(
+                f"Unsupported v2 firewall policy matching_target for {label}: {target}"
             )
-            page = data.get('data', [])
-            all_policies.extend(page)
-            total_count = data.get('totalCount', 0)
-            if offset + len(page) >= total_count:
-                break
-            offset += len(page)
-        return all_policies
+
+        ip_version = {
+            'BOTH': 'IPV4_AND_IPV6',
+            'IPV4': 'IPV4',
+            'IPV6': 'IPV6',
+        }.get(policy.get('ip_version'), policy.get('ip_version'))
+
+        action = {
+            'type': policy.get('action'),
+        }
+        if policy.get('action') == 'ALLOW':
+            action['allowReturnTraffic'] = bool(policy.get('create_allow_respond', False))
+
+        return {
+            'id': policy.get('_id'),
+            'enabled': policy.get('enabled'),
+            'name': policy.get('name'),
+            'description': policy.get('description') or '',
+            'index': policy.get('index'),
+            'loggingEnabled': bool(policy.get('logging', False)),
+            'action': action,
+            'ipProtocolScope': {
+                'ipVersion': ip_version,
+            },
+            'source': translate_side(policy.get('source'), 'source'),
+            'destination': translate_side(policy.get('destination'), 'destination'),
+            'metadata': {
+                'origin': 'SYSTEM_DEFINED' if policy.get('predefined') else 'USER_DEFINED',
+            },
+        }
+
+    def get_firewall_policies(self) -> list:
+        """Fetch firewall policies from UniFi's internal v2 endpoint.
+
+        The Integration API endpoint used here originally is not addressable for
+        every policy: UniFi Network 10.x returns policies created in the
+        controller UI without an ``id`` field, which makes the frontend build a
+        PATCH URL ending in ``/undefined``. The v2 firewall-policies endpoint
+        returns a stable ``_id`` for every policy. This method reads from v2 and
+        reshapes the response into the Integration API schema so callers and the
+        frontend continue to see the same field names.
+
+        The v2 URL uses the classic site name/internal reference (normally
+        ``default``), not the Integration API site UUID discovered elsewhere in
+        this client.
+        """
+        if self._controller_type == 'self_hosted':
+            raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
+
+        site = self.site or 'default'
+        url = f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
+        resp = self._get_session().get(url, timeout=self.TIMEOUT)
+        self._check_integration_permissions(resp)
+        resp.raise_for_status()
+
+        body = resp.json()
+        if isinstance(body, dict) and isinstance(body.get('data'), list):
+            policies = body['data']
+        else:
+            policies = body
+        if not isinstance(policies, list):
+            raise ValueError("Unexpected v2 firewall policy response shape")
+        return [self._v2_policy_to_integration_shape(policy) for policy in policies]
 
     def get_firewall_data(self) -> dict:
         """Fetch policies + zones in one call for the frontend."""
@@ -861,11 +980,60 @@ class UniFiAPI:
         }
 
     def patch_firewall_policy(self, policy_id: str, logging_enabled: bool) -> dict:
-        """Update loggingEnabled on a single policy."""
-        return self._patch_integration_site(
-            f'/firewall/policies/{policy_id}',
-            {'loggingEnabled': logging_enabled}
+        """Update logging on a single firewall policy through the v2 endpoint.
+
+        ``policy_id`` is the v2 Mongo ``_id`` exposed as ``id`` by
+        :meth:`get_firewall_policies`. UniFi's v2 endpoint rejects partial
+        updates, and its batch endpoint has been observed returning 200 without
+        applying changes, so the safe write path is:
+
+        1. read the full v2 policy listing;
+        2. find the exact record by ``_id``;
+        3. flip only the ``logging`` flag; and
+        4. PUT the complete policy body back to ``/firewall-policies/{_id}``.
+
+        The returned value is translated back to the Integration API shape for
+        consistency with the rest of the app.
+        """
+        if self._controller_type == 'self_hosted':
+            raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
+
+        site = self.site or 'default'
+        base_url = f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
+        listing = self._get_session().get(base_url, timeout=self.TIMEOUT)
+        self._check_integration_permissions(listing)
+        listing.raise_for_status()
+
+        body = listing.json()
+        if isinstance(body, dict) and isinstance(body.get('data'), list):
+            policies = body['data']
+        else:
+            policies = body
+        if not isinstance(policies, list):
+            raise ValueError("Unexpected v2 firewall policy response shape")
+
+        record = next((item for item in policies if item.get('_id') == policy_id), None)
+        if record is None:
+            raise ValueError(f"policy not found: {policy_id}")
+        record = dict(record)
+
+        if bool(record.get('logging', False)) == logging_enabled:
+            return self._v2_policy_to_integration_shape(record)
+
+        record['logging'] = logging_enabled
+        resp = self._get_session().put(
+            f"{base_url}/{policy_id}",
+            json=record,
+            timeout=self.TIMEOUT,
         )
+        self._check_integration_permissions(resp)
+        resp.raise_for_status()
+        updated = resp.json()
+        if isinstance(updated, dict) and isinstance(updated.get('data'), dict):
+            updated = updated['data']
+        if not isinstance(updated, dict):
+            raise ValueError("Unexpected v2 firewall policy update response shape")
+        return self._v2_policy_to_integration_shape(updated)
 
     def _patch_one_policy(self, policy_id: str, logging_val: bool) -> dict:
         """Patch a single policy with retry. Returns result dict (thread-safe)."""
@@ -895,7 +1063,7 @@ class UniFiAPI:
     def bulk_patch_logging(self, updates: list[dict], progress_callback=None) -> dict:
         """Batch-update loggingEnabled for multiple policies.
 
-        updates: [{"id": "uuid", "loggingEnabled": bool}, ...]
+        updates: [{"id": "v2-policy-id", "loggingEnabled": bool}, ...]
         progress_callback: optional callable(completed, total, success, failed)
             called after each policy finishes patching.
         Returns summary: {total, success, failed, skipped, retried, errors}

--- a/receiver/unifi_api.py
+++ b/receiver/unifi_api.py
@@ -827,6 +827,49 @@ class UniFiAPI:
         data = self._get_integration_site('/firewall/zones')
         return data.get('data', [])
 
+    def _firewall_policies_v2_url(self) -> str:
+        """Return the v2 firewall policy collection URL for this controller.
+
+        Firewall policies are the only UniFi resource currently read from the
+        internal v2 API. Keeping URL construction in one place prevents the
+        single-policy and bulk paths from drifting if UniFi requires a different
+        site reference in the future.
+        """
+        if self._controller_type == 'self_hosted':
+            raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
+        site = self.site or 'default'
+        return f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
+
+    @staticmethod
+    def _unwrap_v2_list(body) -> list:
+        """Return a v2 list response from either bare-list or ``data`` envelope.
+
+        The observed v2 firewall-policies endpoint returns a bare JSON list, but
+        some UniFi endpoints use a ``{"data": [...]}`` envelope. Supporting both
+        shapes lets the caller stay strict about malformed responses without
+        duplicating the same type checks across read and write paths.
+        """
+        if isinstance(body, dict) and isinstance(body.get('data'), list):
+            return body['data']
+        if isinstance(body, list):
+            return body
+        raise ValueError("Unexpected v2 firewall policy response shape")
+
+    def _get_v2_firewall_policy_records(self) -> list:
+        """Fetch raw v2 firewall policy records without schema translation.
+
+        Public callers use :meth:`get_firewall_policies`, which reshapes records
+        for the frontend. The raw records are needed for writes because UniFi's
+        v2 endpoint rejects partial updates and requires the full policy body.
+        """
+        resp = self._get_session().get(
+            self._firewall_policies_v2_url(),
+            timeout=self.TIMEOUT,
+        )
+        self._check_integration_permissions(resp)
+        resp.raise_for_status()
+        return self._unwrap_v2_list(resp.json())
+
     @staticmethod
     def _v2_policy_to_integration_shape(policy: dict) -> dict:
         """Translate a v2 firewall policy record to the Integration API shape.
@@ -945,22 +988,7 @@ class UniFiAPI:
         ``default``), not the Integration API site UUID discovered elsewhere in
         this client.
         """
-        if self._controller_type == 'self_hosted':
-            raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
-
-        site = self.site or 'default'
-        url = f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
-        resp = self._get_session().get(url, timeout=self.TIMEOUT)
-        self._check_integration_permissions(resp)
-        resp.raise_for_status()
-
-        body = resp.json()
-        if isinstance(body, dict) and isinstance(body.get('data'), list):
-            policies = body['data']
-        else:
-            policies = body
-        if not isinstance(policies, list):
-            raise ValueError("Unexpected v2 firewall policy response shape")
+        policies = self._get_v2_firewall_policy_records()
         return [self._v2_policy_to_integration_shape(policy) for policy in policies]
 
     def get_firewall_data(self) -> dict:
@@ -979,7 +1007,12 @@ class UniFiAPI:
             'loggingDisabled': logging_disabled,
         }
 
-    def patch_firewall_policy(self, policy_id: str, logging_enabled: bool) -> dict:
+    def patch_firewall_policy(
+        self,
+        policy_id: str,
+        logging_enabled: bool,
+        policy_record: dict | None = None,
+    ) -> dict:
         """Update logging on a single firewall policy through the v2 endpoint.
 
         ``policy_id`` is the v2 Mongo ``_id`` exposed as ``id`` by
@@ -994,25 +1027,18 @@ class UniFiAPI:
 
         The returned value is translated back to the Integration API shape for
         consistency with the rest of the app.
+
+        ``policy_record`` is an optional raw v2 record supplied by the bulk
+        update path after it has fetched the listing once. Single-policy callers
+        leave it unset and this method fetches the listing itself.
         """
-        if self._controller_type == 'self_hosted':
-            raise NotImplementedError("Firewall policy v2 API not available on self-hosted controllers")
-
-        site = self.site or 'default'
-        base_url = f"{self.host}/proxy/network/v2/api/site/{site}/firewall-policies"
-        listing = self._get_session().get(base_url, timeout=self.TIMEOUT)
-        self._check_integration_permissions(listing)
-        listing.raise_for_status()
-
-        body = listing.json()
-        if isinstance(body, dict) and isinstance(body.get('data'), list):
-            policies = body['data']
+        base_url = self._firewall_policies_v2_url()
+        if policy_record is None:
+            policies = self._get_v2_firewall_policy_records()
+            record = next((item for item in policies if item.get('_id') == policy_id), None)
         else:
-            policies = body
-        if not isinstance(policies, list):
-            raise ValueError("Unexpected v2 firewall policy response shape")
+            record = policy_record if policy_record.get('_id') == policy_id else None
 
-        record = next((item for item in policies if item.get('_id') == policy_id), None)
         if record is None:
             raise ValueError(f"policy not found: {policy_id}")
         record = dict(record)
@@ -1035,13 +1061,25 @@ class UniFiAPI:
             raise ValueError("Unexpected v2 firewall policy update response shape")
         return self._v2_policy_to_integration_shape(updated)
 
-    def _patch_one_policy(self, policy_id: str, logging_val: bool) -> dict:
+    def _patch_one_policy(
+        self,
+        policy_id: str,
+        logging_val: bool,
+        policy_record: dict | None = None,
+    ) -> dict:
         """Patch a single policy with retry. Returns result dict (thread-safe)."""
         max_retries = 3
         retried = 0
         for attempt in range(max_retries):
             try:
-                self.patch_firewall_policy(policy_id, logging_val)
+                if policy_record is None:
+                    self.patch_firewall_policy(policy_id, logging_val)
+                else:
+                    self.patch_firewall_policy(
+                        policy_id,
+                        logging_val,
+                        policy_record=policy_record,
+                    )
                 return {'status': 'success', 'retried': retried}
             except requests.HTTPError as e:
                 status = e.response.status_code if e.response is not None else 0
@@ -1091,11 +1129,25 @@ class UniFiAPI:
         # Ensure session is initialized before spawning threads (avoids lazy-init race)
         self._get_session()
 
+        policy_map = None
+        try:
+            policy_map = {
+                policy.get('_id'): policy
+                for policy in self._get_v2_firewall_policy_records()
+            }
+        except Exception as e:
+            logger.warning("Bulk patch: v2 policy prefetch failed, falling back to per-policy reads: %s", e)
+
         # Patch concurrently (4 workers keeps controller happy)
         successful_ids = set()
         with ThreadPoolExecutor(max_workers=4) as pool:
             futures = {
-                pool.submit(self._patch_one_policy, item['id'], item['loggingEnabled']): item
+                pool.submit(
+                    self._patch_one_policy,
+                    item['id'],
+                    item['loggingEnabled'],
+                    policy_map.get(item['id']) if policy_map is not None else None,
+                ): item
                 for item in work_items
             }
             for future in as_completed(futures):

--- a/ui/src/__tests__/firewallPolicyLogging.test.js
+++ b/ui/src/__tests__/firewallPolicyLogging.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { isControllablePolicy } from '../lib/firewallPolicyLogging'
+
+describe('isControllablePolicy', () => {
+  it('allows enabled user policies with addressable ids', () => {
+    expect(isControllablePolicy({
+      id: '65f31c0a1234567890abcdef',
+      enabled: true,
+      metadata: { origin: 'USER_DEFINED' },
+    })).toBe(true)
+  })
+
+  it('rejects policies without ids so PATCH cannot target undefined', () => {
+    expect(isControllablePolicy({
+      enabled: true,
+      metadata: { origin: 'USER_DEFINED' },
+    })).toBe(false)
+    expect(isControllablePolicy({
+      id: '',
+      enabled: true,
+      metadata: { origin: 'USER_DEFINED' },
+    })).toBe(false)
+  })
+
+  it('keeps existing derived and disabled guards', () => {
+    expect(isControllablePolicy({
+      id: 'derived-policy',
+      metadata: { origin: 'DERIVED' },
+    })).toBe(false)
+    expect(isControllablePolicy({
+      id: 'disabled-policy',
+      enabled: false,
+      metadata: { origin: 'USER_DEFINED' },
+    })).toBe(false)
+  })
+})

--- a/ui/src/lib/firewallPolicyLogging.js
+++ b/ui/src/lib/firewallPolicyLogging.js
@@ -8,6 +8,7 @@
 /** Whether a policy can have its logging toggled. */
 export function isControllablePolicy(policy) {
   if (!policy) return false
+  if (!policy.id) return false
   if (policy.metadata?.origin === 'DERIVED') return false
   if (policy.enabled === false) return false
   return true


### PR DESCRIPTION
# fix(unifi): use v2 firewall policy endpoint for logging toggles

Fixes #112

## Why

Firewall logging toggles currently fail for UniFi Network UI-created policies because the Integration API returns those policies without an addressable `id`.

Observed on a real UDM Pro / Network 10.3.58 deployment:

- 89 firewall policies total
- 69 have Integration API `id`
- 20 are missing `id`
- the missing-id policies are all `USER_DEFINED` rules created through the UniFi Network UI

When one of those policies is toggled, the frontend ends up patching `/api/firewall/policies/undefined`, and the controller returns HTTP 400 for:

```
/proxy/network/integration/v1/sites/<uuid>/firewall/policies/undefined
```

The v2 internal endpoint returns `_id` for every policy, and `PUT /proxy/network/v2/api/site/default/firewall-policies/{_id}` works as long as the full v2 policy body is sent.

## What changed

### `receiver/unifi_api.py`

- `get_firewall_policies()` now reads from the v2 firewall-policies endpoint and reshapes each v2 record back into the existing Integration API schema.
- New `_v2_policy_to_integration_shape()` translator covers the policy fields UIP already uses:
  - top-level `id`, `enabled`, `name`, `description`, `index`, `loggingEnabled`
  - `action.type` and ALLOW `allowReturnTraffic`
  - `ipProtocolScope.ipVersion`
  - `metadata.origin`
  - `source` / `destination` zone ids and traffic filters for `ANY`, `APP`, `IP`, and `NETWORK`
- Unknown v2 `matching_target` values raise instead of silently dropping filters.
- `patch_firewall_policy()` now fetches the full v2 listing, finds the record by `_id`, flips only `logging`, and PUTs the complete body back.
- No-op logging changes return the translated record without a PUT.

### `receiver/tests/test_v2_policy_translation.py`

New tests cover the translator and the v2 read/write behavior:

| Area | Test coverage |
|---|---|
| Translator | `ANY`, `APP`, `IP`, `NETWORK`, `predefined`, ALLOW return traffic, `BOTH` -> `IPV4_AND_IPV6` |
| Drift handling | unknown `matching_target` raises |
| Read path | `get_firewall_policies()` calls the v2 endpoint and returns Integration-shaped records with ids |
| Write path | `patch_firewall_policy()` PUTs the full v2 body, skips no-op PUTs, and raises clearly for missing ids |
| Live smoke | optional controller round-trip test, skipped unless `UNIFI_LIVE_FIREWALL_TOGGLE=1` |

### `README.md`

Updated the Firewall Syslog Manager feature line to mention support for rules created in the UniFi Network UI.

## Tests

Red first:

```text
tests/test_v2_policy_translation.py
10 failed, 1 skipped
```

Final branch:

```text
./.venv/bin/python -m pytest
618 passed, 1 skipped in 1.53s
```

The skipped test is the explicit live-controller toggle smoke test.

## Backwards compatibility

| Surface | Before | After |
|---|---|---|
| Frontend policy shape | Integration API field names | Same field names |
| Policy id sent to frontend | Integration `id`, missing on UI-created policies | v2 `_id` presented as `id`, populated for all policies |
| Single logging toggle | Integration API PATCH by id | v2 GET full record + PUT full body |
| Bulk logging toggle | calls `patch_firewall_policy()` per policy, then verifies | same route-level behavior, now works for UI-created policies too |
| Zones/devices/clients/site discovery | Integration / Classic APIs | unchanged |
| DB/env/dependencies | unchanged | unchanged |

## Out of scope

- No general v2 API client abstraction.
- No frontend or DB changes.
- No attempt to translate inner v2 network/application ids back to Integration API ids; logging toggles only write the top-level policy `_id` and `logging` flag.
- No v2 batch endpoint usage, because it was observed returning 200 without applying writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Firewall Syslog Manager, prerequisites (UniFi OS support), and how bulk toggle and policy/zone IDs behave.

* **Improvements**
  * Switched firewall policy/zone handling to use Network v2 endpoints so UI-created policies and zone IDs remain addressable; safer logging toggles via full-record updates.

* **Bug Fixes**
  * Restored consistent zone matrix rendering and avoided invalid PATCHes using synthesized IDs.

* **Tests**
  * Added unit/integration tests and a gated live smoke test covering v2 policy/zone translation and logging toggles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmasarweh/UniFi-Insights-Plus/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->