### PR TITLE
fix: add missing user field to geoip cron.d entry

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,7 @@ DatabaseDirectory /app/maxmind
 GEOEOF
 
     # Schedule: Wednesday 07:00 UTC and Saturday 07:00 UTC
-    echo "0 7 * * 3,6 /app/geoip-update.sh >> /var/log/geoip-update.log 2>&1" > /etc/cron.d/geoipupdate
+    echo "0 7 * * 3,6 root /app/geoip-update.sh >> /var/log/geoip-update.log 2>&1" > /etc/cron.d/geoipupdate
     chmod 0644 /etc/cron.d/geoipupdate
 
     # Run an initial update if databases are missing


### PR DESCRIPTION
Files in `/etc/cron.d/` use system crontab format, which requires a username field between the schedule and the command. The current entry is missing it:

```
0 7 * * 3,6 /app/geoip-update.sh >> /var/log/geoip-update.log 2>&1
```

Without the user field, cron silently skips the line. The GeoIP databases never update after image build — they stay at whatever was baked in during `docker build`.

**Fix:** Add `root` in the right spot:

```
0 7 * * 3,6 root /app/geoip-update.sh >> /var/log/geoip-update.log 2>&1
```

I confirmed this by comparing with the working `/etc/cron.d/e2scrub_all` already in the container, which has `root` in the correct position. Manual runs via `docker exec unifi-log-insight /app/geoip-update.sh` work fine — it's just the cron that never fires.

Fixes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GeoIP auto-update configuration for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmasarweh/UniFi-Insights-Plus/pull/115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->