### PR TITLE
feat(parser): add UniFi CEF threat parsing

### DIFF
--- a/receiver/backfill.py
+++ b/receiver/backfill.py
@@ -419,7 +419,7 @@ class BackfillTask:
                     self.db.enqueue_threat_backfill(remote_ip, source='cef_backfill')
                     queued_remote_ips.add(remote_ip)
                 except Exception:
-                    logger.debug("CEF backfill failed to enqueue %s", remote_ip, exc_info=True)
+                    logger.warning("CEF backfill failed to enqueue %s", remote_ip, exc_info=True)
             updates.append((row_id, parsed))
 
         if updates:

--- a/receiver/backfill.py
+++ b/receiver/backfill.py
@@ -26,6 +26,7 @@ QUEUE_BATCH_SIZE = 50             # IPs per queue pass
 STALE_REENRICH_BATCH = 10         # Stale IPs per pass
 SERVICE_NAME_BATCH_SIZE = 1000    # Rows per service-name cursor batch
 RULE_ACTION_BATCH_SIZE = 500      # Rows per rule-action cursor batch
+CEF_PARSER_BATCH_SIZE = 500       # Rows per CEF backfill cursor batch
 
 
 class BackfillTask:
@@ -70,6 +71,7 @@ class BackfillTask:
         # One-shot migrations (ID cursor, persisted progress)
         self._service_name_migration()
         self._backfill_rule_action()
+        self._backfill_cef_parser()
         self._orphan_queue_seed()
 
         # Queue worker: process deferred threat lookups
@@ -331,6 +333,103 @@ class BackfillTask:
                          len(updates), last_id)
 
         set_config(self.db, 'rule_action_backfill_last_id', last_id)
+
+    # ── One-shot CEF parser backfill ─────────────────────────────────────────
+
+    def _backfill_cef_parser(self):
+        """One-shot ID-cursor backfill of historical CEF threat events.
+
+        UniFi Network 10.x's "SIEM Server" Activity Logging emits IDS/IPS
+        threat events in CEF format. Before the CEF parser was added,
+        these rows were stored as ``log_type='system'`` with every
+        structured field null — so the Threats counter, Threat Map, and
+        Dataflow views had nothing to draw. This backfill re-parses those
+        historical rows in place using :func:`parsers.parse_cef_threat`, so
+        UIP's analytics surfaces immediately reflect the past data after
+        a deploy (rather than only new events arriving going forward).
+
+        Behaviour:
+            - Gated by ``cef_parser_backfill_done`` in ``system_config``;
+              runs at most once per deployment.
+            - ID-cursor based with progress persisted to
+              ``cef_parser_backfill_last_id``, so an interrupted run
+              resumes from where it left off.
+            - One batch (:data:`CEF_PARSER_BATCH_SIZE`) per cycle to keep
+              IO bounded — full backfill of a typical home installation
+              (tens of thousands of rows) completes within a handful of
+              :data:`QUEUE_WORKER_INTERVAL` cycles without IO spikes
+              (see issue #67 for the IO-spike history this design avoids).
+            - Skips rows whose raw_log doesn't actually parse as a threat
+              event despite matching the pre-filter regex — defensive,
+              shouldn't happen in practice.
+
+        Performance note: like ``_backfill_rule_action``, Postgres
+        applies the regex filter during the index scan. For sparse
+        matches across a large id range, individual batches may scan
+        wide ranges. This is a one-time migration cost.
+        """
+        from db import get_config, set_config
+        from parsers import parse_cef_threat
+
+        if get_config(self.db, 'cef_parser_backfill_done', False):
+            return
+
+        last_id = get_config(self.db, 'cef_parser_backfill_last_id', 0) or 0
+
+        rows = self.db.cef_parser_backfill_batch(last_id, CEF_PARSER_BATCH_SIZE)
+        if not rows:
+            set_config(self.db, 'cef_parser_backfill_done', True)
+            logger.info("CEF parser backfill complete (cursor at id=%d)", last_id)
+            return
+
+        updates: list[tuple[int, dict]] = []
+        queued_remote_ips: set[str] = set()
+        for row_id, raw_log in rows:
+            last_id = row_id
+            # The CEF body lives somewhere inside the full ``raw_log``
+            # (after the syslog header). Locate the marker and slice
+            # rather than trying to reuse SYSLOG_HEADER — this is robust
+            # against minor header variations across UniFi versions.
+            cef_idx = raw_log.find('CEF:0|Ubiquiti|')
+            if cef_idx == -1:
+                # Pre-filter regex matched yet the marker is missing —
+                # defensive only; should be unreachable in practice.
+                continue
+            parsed = parse_cef_threat(raw_log[cef_idx:])
+            if parsed is None:
+                # Pre-filter said "looks like a threat" but the full
+                # parser disagreed (e.g. malformed extensions). Skip
+                # silently; the raw_log stays intact in the row.
+                continue
+            # Apply the local pieces of the live enrichment pipeline
+            # (geo_*, asn_*, rdns, remote_ip, device names) but skip
+            # synchronous AbuseIPDB calls. A historical parser backfill
+            # can examine hundreds of rows per cycle; direct API lookups
+            # here would burn through free-tier quota. Unknown remote IPs
+            # are queued below for the normal deferred worker instead.
+            parsed = self.enricher.enrich(parsed, include_threat=False)
+
+            remote_ip = parsed.get('remote_ip')
+            if (remote_ip
+                    and parsed.get('log_type') == 'firewall'
+                    and parsed.get('rule_action') == 'block'
+                    and self.abuseipdb.enabled
+                    and remote_ip not in queued_remote_ips):
+                try:
+                    self.db.enqueue_threat_backfill(remote_ip, source='cef_backfill')
+                    queued_remote_ips.add(remote_ip)
+                except Exception:
+                    logger.debug("CEF backfill failed to enqueue %s", remote_ip, exc_info=True)
+            updates.append((row_id, parsed))
+
+        if updates:
+            patched = self.db.patch_cef_parsed_logs(updates)
+            logger.debug(
+                "CEF parser backfill: %d rows patched in batch (cursor at id=%d)",
+                patched, last_id,
+            )
+
+        set_config(self.db, 'cef_parser_backfill_last_id', last_id)
 
     def _orphan_queue_seed(self):
         """One-time seed: scan historical logs for orphan IPs missing from ip_threats.

--- a/receiver/db.py
+++ b/receiver/db.py
@@ -1654,6 +1654,107 @@ END $$;""",
                 )
                 return len(updates)
 
+    # ── CEF parser backfill (one-shot) ────────────────────────────────────────
+    #
+    # Columns patched per row when reparsing a CEF threat event. Order must
+    # match the SQL ``SET`` clause in :meth:`patch_cef_parsed_logs`. Listing
+    # them as a tuple makes the contract explicit and lets tests assert
+    # column coverage without coupling to the SQL string.
+    #
+    # The set is intentionally broad: the backfill runs each row through the
+    # local pieces of ``Enricher.enrich`` which populate GeoIP (geo_*), ASN
+    # (asn_*), reverse DNS (rdns), device names, and remote_ip in addition to
+    # the parser-set columns. Without these, historical CEF threat rows would
+    # never appear on the Threat Map (which filters on
+    # ``geo_lat IS NOT NULL AND geo_lon IS NOT NULL``).
+    CEF_BACKFILL_COLUMNS = (
+        # Parser-set
+        'log_type', 'src_ip', 'dst_ip', 'src_port', 'dst_port',
+        'protocol', 'service_name', 'rule_action', 'rule_name', 'rule_desc',
+        'direction', 'threat_score', 'threat_categories', 'mac_address',
+        # Enrichment-set (Enricher.enrich)
+        'remote_ip',
+        'geo_country', 'geo_city', 'geo_lat', 'geo_lon',
+        'asn_number', 'asn_name',
+        'rdns',
+        'abuse_usage_type', 'abuse_hostnames', 'abuse_total_reports',
+        'abuse_last_reported', 'abuse_is_whitelisted', 'abuse_is_tor',
+        'src_device_name', 'dst_device_name',
+    )
+
+    # Postgres POSIX-regex pattern that matches the body of any UniFi CEF
+    # threat event (vendor=Ubiquiti, ECID 2xx, name starting with "Threat").
+    # Used by the backfill batch query to filter at the DB layer so we don't
+    # pull every ``system``-typed row across the wire.
+    CEF_THREAT_PATTERN = r'CEF:0\|Ubiquiti\|[^|]*\|[^|]*\|2\d\d\|Threat'
+
+    def cef_parser_backfill_batch(self, last_id: int, batch_size: int = 500):
+        """Read a batch of unparsed CEF threat rows for the one-shot backfill.
+
+        Selects ``log_type='system'`` rows (those ingested before the CEF
+        parser was deployed) whose ``raw_log`` matches the CEF threat
+        pattern. Uses an ID cursor so progress survives restarts.
+
+        Args:
+            last_id: Highest log id already processed; only rows with
+                ``id > last_id`` are returned.
+            batch_size: Maximum number of rows to fetch in one call.
+
+        Returns:
+            List of ``(id, raw_log)`` tuples ordered by ``id`` ascending,
+            empty when the cursor has reached the end of the table.
+        """
+        with self.get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT id, raw_log FROM logs "
+                    "WHERE id > %s "
+                    "  AND log_type = 'system' "
+                    "  AND raw_log ~ %s "
+                    "ORDER BY id LIMIT %s",
+                    [last_id, self.CEF_THREAT_PATTERN, batch_size]
+                )
+                return cur.fetchall()
+
+    def patch_cef_parsed_logs(self, updates: list[tuple]) -> int:
+        """Batch-update logs with CEF-parsed fields, in place.
+
+        Each entry in ``updates`` is ``(log_id, parsed_dict)`` where
+        ``parsed_dict`` is the return value of :func:`parsers.parse_cef`.
+        Any keys missing from the dict are written as ``NULL`` — this is
+        intentional and safe because the rows being patched were previously
+        ``log_type='system'`` with all structured fields already null.
+
+        The ``WHERE log_type = 'system'`` guard is a safety belt: should
+        a concurrent process have already retyped the row (e.g. a manual
+        admin update), this skips it rather than clobbering. Matching is
+        keyed by ``id`` so the guard is essentially free.
+
+        Args:
+            updates: List of ``(log_id, parsed_dict)`` tuples.
+
+        Returns:
+            Number of rows attempted (not guaranteed actually updated —
+            see the safety guard above). Returns 0 for an empty list.
+        """
+        if not updates:
+            return 0
+
+        set_clause = ', '.join(f'{c} = %s' for c in self.CEF_BACKFILL_COLUMNS)
+        sql = f"UPDATE logs SET {set_clause} WHERE id = %s AND log_type = 'system'"
+
+        rows = [
+            tuple(parsed.get(col) for col in self.CEF_BACKFILL_COLUMNS) + (log_id,)
+            for log_id, parsed in updates
+        ]
+
+        with self.get_conn() as conn:
+            with conn.cursor() as cur:
+                extras.execute_batch(cur, sql, rows, page_size=500)
+                conn.commit()
+
+        return len(updates)
+
     def get_queue_stats(self) -> dict:
         """Return queue statistics for logging/monitoring."""
         with self.get_conn() as conn:

--- a/receiver/enrichment.py
+++ b/receiver/enrichment.py
@@ -143,6 +143,62 @@ def get_abuseipdb_stats(db):
     return stats
 
 
+# ── Threat-data merging ───────────────────────────────────────────────────────
+
+def _merge_threat_data(parsed: dict, threat_data: dict) -> None:
+    """In-place merge of enriched threat data into a parsed log dict.
+
+    Preserves any parser-derived threat signal that would otherwise be
+    silently clobbered by ``parsed.update(threat_data)``. Two fields
+    receive special handling:
+
+    - ``threat_score``: takes ``max()`` of existing and incoming. UniFi
+      CEF threat events arrive with ``threat_score`` already set by
+      :func:`parsers.parse_cef_threat` from the qualitative
+      ``UNIFIrisk`` field (low=20, medium=60, high=80, critical=95). If
+      the source IP is not in AbuseIPDB's database, the lookup returns
+      ``threat_score=0`` — overwriting the UniFi signal would make the
+      event disappear from the ``threat_score > 50`` Threats counter.
+      Taking ``max()`` keeps the more alarming reading regardless of
+      provenance.
+    - ``threat_categories``: unioned (order-preserving, deduplicated).
+      UniFi populates a single-element list from ``UNIFIipsSignature``
+      (e.g. ``"ET DROP Dshield Block Listed Source group 1"``); AbuseIPDB
+      contributes its own category labels. Both are useful for filtering
+      and alerting, so we keep both rather than picking one.
+
+    All other ``threat_data`` keys (``abuse_usage_type``, ``abuse_hostnames``,
+    ``abuse_total_reports``, ``abuse_last_reported``, ``abuse_is_whitelisted``,
+    ``abuse_is_tor``, etc.) use ordinary :py:meth:`dict.update` semantics —
+    they are AbuseIPDB-only fields with no parser-set counterpart.
+
+    Args:
+        parsed: The parsed log dict being enriched (mutated in place).
+        threat_data: Dict returned by :meth:`AbuseIPDBEnricher.lookup`,
+            typically containing ``threat_score`` and
+            ``threat_categories`` plus AbuseIPDB-specific detail fields.
+    """
+    # Copy so caller's dict isn't mutated (defensive; callers don't rely
+    # on this, but it makes the merge predictable for tests).
+    incoming = dict(threat_data)
+
+    existing_score = parsed.get('threat_score')
+    new_score = incoming.get('threat_score')
+    if existing_score is not None and new_score is not None:
+        incoming['threat_score'] = max(existing_score, new_score)
+
+    existing_cats = parsed.get('threat_categories') or []
+    new_cats = incoming.get('threat_categories') or []
+    if existing_cats:
+        merged = list(existing_cats)
+        for cat in new_cats:
+            if cat not in merged:
+                merged.append(cat)
+        incoming['threat_categories'] = merged
+
+    parsed.update(incoming)
+
+
 # ── Thread-safe cache ─────────────────────────────────────────────────────────
 
 class TTLCache:
@@ -840,7 +896,7 @@ class Enricher:
                 logger.debug("touch_threat_last_seen failed for %s", ip, exc_info=True)
             self._recently_touched[ip] = time.monotonic()
 
-    def enrich(self, parsed: dict) -> dict:
+    def enrich(self, parsed: dict, include_threat: bool = True) -> dict:
         """Enrich a parsed log entry with GeoIP, ASN, threat, and rDNS data.
 
         Strategy:
@@ -849,6 +905,12 @@ class Enricher:
         - rDNS: all remote public IPs
 
         WAN and gateway IPs are excluded — they belong to us, not the remote party.
+
+        Args:
+            parsed: Parsed log dict to enrich in place.
+            include_threat: When false, skip synchronous AbuseIPDB lookups and
+                queue writes. Historical backfills use this to keep API usage
+                bounded while still applying local GeoIP/ASN/rDNS enrichment.
         """
         # Auto-exclude WAN IPs (v4 + v6) from enrichment as they're learned
         from parsers import get_wan_ip
@@ -941,17 +1003,24 @@ class Enricher:
             if rdns_data.get('rdns'):
                 parsed['rdns'] = rdns_data['rdns']
 
-        # AbuseIPDB (blocked firewall events, or pihole with threat enabled)
+        if not include_threat:
+            return parsed
+
+        # AbuseIPDB (blocked firewall events, or pihole with threat enabled).
+        # Use ``_merge_threat_data`` rather than ``parsed.update`` so any
+        # parser-set threat_score / threat_categories (e.g. from UniFi CEF
+        # threat events) survives an AbuseIPDB cache miss that returns
+        # ``threat_score=0``. See the helper's docstring for details.
         if (is_pihole and self._pihole_enrichment in ('threat', 'both')):
             threat_data = self.abuseipdb.lookup(ip_to_enrich)
             if threat_data:
-                parsed.update(threat_data)
+                _merge_threat_data(parsed, threat_data)
                 self._touch_threat_coalesced(ip_to_enrich)
         elif (parsed.get('log_type') == 'firewall'
                 and parsed.get('rule_action') == 'block'):
             threat_data = self.abuseipdb.lookup(ip_to_enrich)
             if threat_data:
-                parsed.update(threat_data)
+                _merge_threat_data(parsed, threat_data)
                 self._touch_threat_coalesced(ip_to_enrich)
             elif self.abuseipdb.enabled and self._db:
                 # Enqueue for deferred lookup — coalesced, only when AbuseIPDB is configured

--- a/receiver/parsers.py
+++ b/receiver/parsers.py
@@ -2,7 +2,20 @@
 UniFi Log Insight - Syslog Parsers
 
 Parses UDR syslog messages into structured data.
-Log types: firewall, dns, dhcp, wifi
+
+Log types:
+    firewall  - block/allow/redirect packet events. Two sub-formats live
+                here: classic iptables/netfilter kernel logs (SRC=/DST=/
+                PROTO=) and CEF-formatted IDS/IPS threat events from
+                Network 10.x's "SIEM Server" Activity Logging mode. They
+                share a log_type because from a user perspective both
+                are firewall block decisions; the ``rule_desc`` column
+                distinguishes them (``IDS/IPS`` for the latter).
+    dns       - dnsmasq queries/replies/forwards
+    dhcp      - dnsmasq-dhcp lease events
+    wifi      - hostapd / stamgr / stahtd events
+    system    - catch-all for anything else (UDM internals, kernel,
+                non-threat CEF subcategories, etc.)
 """
 
 import os
@@ -72,6 +85,68 @@ DHCP_REQ     = re.compile(rf'DHCPREQUEST\((\S+)\)\s+([0-9a-fA-F:.]+)\s+({MAC_PAT
 # ── WiFi (stamgr / hostapd) ───────────────────────────────────────────────────
 WIFI_EVENT  = re.compile(r'(\w+):\s+STA\s+([0-9a-f:]+)')
 WIFI_ASSOC  = re.compile(r'STA\s+([0-9a-f:]+)\s+.*?(associated|disassociated|deauthenticated|authenticated)')
+
+# ── CEF (UniFi Network 10.x "SIEM Server" Activity Logging) ───────────────────
+#
+# Network 10.x's CyberSecure → Traffic Logging → Activity Logging feature can
+# forward security events in CEF (Common Event Format) instead of the classic
+# per-daemon syslog stream. A typical threat line looks like:
+#
+#     CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|
+#         UNIFIcategory=Security proto=UDP spt=123 dpt=64280 act=blocked
+#         src=176.65.148.67 dst=192.168.200.56 UNIFIrisk=medium ...
+#
+# Header columns are pipe-delimited:
+#   CEF:VERSION | VENDOR | PRODUCT | DEVICE_VERSION | EVENT_CLASS_ID | NAME | SEVERITY | EXTENSIONS
+#
+# Reference: https://docs.microfocus.com/doc/cef and the upstream UniFi help
+# article on SIEM integration.
+CEF_HEADER = re.compile(
+    r'^CEF:(?P<version>\d+)\|'
+    r'(?P<vendor>[^|]*)\|'
+    r'(?P<product>[^|]*)\|'
+    r'(?P<device_version>[^|]*)\|'
+    r'(?P<event_class_id>[^|]*)\|'
+    r'(?P<name>[^|]*)\|'
+    r'(?P<severity>\d+)\|'
+    r'(?P<extensions>.*)$'
+)
+
+# Tokeniser for CEF extension key=value pairs. Keys are alphanumeric;
+# values run until the next ``\s+key=`` boundary or end-of-line. The
+# ``msg=`` extension is handled separately (see _parse_cef_extensions)
+# because its value can legitimately contain ``=`` and arbitrary spaces.
+CEF_EXT_KV = re.compile(r'\b([a-zA-Z]\w*)=(.*?)(?=\s+[a-zA-Z]\w+=|$)')
+
+# Fast pre-match used by ``detect_log_type`` to identify threat-class CEF
+# events without parsing the full header. ECID 2xx is UniFi's range for
+# Suricata-derived IDS/IPS detections.
+CEF_THREAT_PREMATCH = re.compile(r'^CEF:0\|Ubiquiti\|[^|]*\|[^|]*\|2\d\d\|Threat\b')
+
+# Map UniFi's qualitative ``UNIFIrisk`` levels to an integer score that
+# fits the ``threat_score`` schema column (0-100, also used by AbuseIPDB).
+# Letting both producers write the same column means dashboards can
+# sort/filter on a single field regardless of provenance.
+#
+# Note: the UIP "Threats" stats counter uses ``threat_score > 50`` (strict),
+# so ``medium`` is mapped to 60 rather than 50. UniFi labels verified
+# threat-intel hits (e.g. DShield Block List) as "medium", and surfacing
+# those in the Threats counter matches user intent.
+_UNIFI_RISK_SCORE: dict[str, int] = {
+    'low': 20,
+    'medium': 60,
+    'high': 80,
+    'critical': 95,
+}
+
+# Translate UniFi CEF direction values to UIP's ``direction`` enum.
+# UIP uses {inbound, outbound, inter_vlan, nat}; UniFi CEF emits
+# {incoming, outgoing}. The inter_vlan and nat values do not have
+# direct CEF analogues.
+_UNIFI_DIRECTION: dict[str, str] = {
+    'incoming': 'inbound',
+    'outgoing': 'outbound',
+}
 
 # Module-level config (set by main.py after DB initialization)
 WAN_INTERFACES = {'ppp0'}  # Default fallback
@@ -455,13 +530,240 @@ def parse_wifi(body: str) -> dict:
     return result
 
 
+def _parse_cef_extensions(ext_str: str) -> dict[str, str]:
+    """Parse the extension portion of a CEF line into a key→value dict.
+
+    CEF extensions are space-separated ``key=value`` pairs. Keys are
+    alphanumeric (plus underscore); values run until the next ``key=``
+    boundary or end-of-line. The ``msg=`` extension is special-cased
+    because its value can legitimately contain spaces, ``=`` characters
+    and other punctuation that would otherwise corrupt tokenisation —
+    it is extracted up front, then the remainder is fed to the
+    key=value tokeniser.
+
+    Args:
+        ext_str: The extension substring captured by ``CEF_HEADER`` as
+            the ``extensions`` named group.
+
+    Returns:
+        Dict mapping extension keys to (string) values. Empty values are
+        dropped so callers can use simple ``.get(key)``-then-truthy
+        checks without ambiguity.
+    """
+    extensions: dict[str, str] = {}
+    main_part = ext_str
+
+    # msg= is greedy-to-end-of-line; pull it out before tokenising the rest.
+    # Use ``rfind`` (not ``find``) because earlier extension *values* can
+    # legitimately contain the literal substring " msg=" — e.g. an IPS
+    # signature whose description happens to include those characters.
+    # UniFi always emits msg= as the final extension, so the last
+    # occurrence is the actual msg boundary.
+    if ' msg=' in ext_str:
+        msg_idx = ext_str.rfind(' msg=')
+        extensions['msg'] = ext_str[msg_idx + len(' msg='):]
+        main_part = ext_str[:msg_idx]
+    elif ext_str.startswith('msg='):
+        extensions['msg'] = ext_str[len('msg='):]
+        main_part = ''
+
+    for match in CEF_EXT_KV.finditer(main_part):
+        key = match.group(1)
+        value = match.group(2).strip()
+        if value:
+            extensions[key] = value
+
+    return extensions
+
+
+def parse_cef_threat(body: str) -> dict | None:
+    """Parse a CEF threat-class event from UniFi Activity Logging.
+
+    UniFi Network 10.x's *SIEM Server* mode (configured under
+    Settings → CyberSecure → Traffic Logging → Activity Logging → SIEM Server)
+    forwards security events in CEF (Common Event Format) instead of the
+    classic per-daemon syslog format. A representative threat event::
+
+        CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|
+            UNIFIcategory=Security proto=UDP spt=123 dpt=64280 act=blocked
+            src=176.65.148.67 dst=192.168.200.56 UNIFIrisk=medium
+            UNIFIpolicyName=DShield Block List UNIFIpolicyType=IDS/IPS
+            UNIFIdirection=incoming UNIFIsrcRegion=NL ...
+
+    This parser handles **only** the threat / IDS-IPS subset of CEF
+    events (event class ID 2xx, ``name`` beginning with "Threat"),
+    mapping CEF header fields and ``UNIFI*`` extensions to UIP's
+    existing ``logs`` schema columns. Other CEF subcategories (audit
+    ``5xx``, device ``3xx``, wifi ``4xx``, client, vpn, OS-level
+    ``11xx``) are intentionally out of scope here and return ``None``
+    so :func:`parse_log` falls back to :func:`parse_system` —
+    preserving prior behaviour for those events while we incrementally
+    add dedicated routing as the UI gains corresponding views.
+
+    Threat events are returned with ``log_type='firewall'`` so they
+    inherit UIP's existing FIREWALL filter button, BLOCK action filter,
+    Flow View, etc. The ``rule_desc='IDS/IPS'`` column distinguishes
+    them from netfilter blocks for callers that care.
+
+    Notes:
+        - Protocol values are lower-cased to match the iptables firewall
+          parser convention (so e.g. ``UDP`` becomes ``'udp'``).
+        - ``geo_country`` is set from the **external** party's region:
+          ``UNIFIsrcRegion`` for inbound flows, ``UNIFIdstRegion`` for
+          outbound. When direction is unknown but only one side has a
+          region populated, that side is used.
+        - ``threat_score`` is derived from the qualitative ``UNIFIrisk``
+          field via :data:`_UNIFI_RISK_SCORE`. Unknown levels yield no
+          score (rather than guessing a default).
+        - Integer fields (ports) are parsed defensively: malformed values
+          are silently skipped rather than raising. The receiver thread
+          must never crash on bad packets (see issue #110).
+
+    Args:
+        body: The syslog message **body** — i.e. what
+            :data:`SYSLOG_HEADER` captures as the ``body`` group, after
+            any leading RFC3164 priority prefix and the standard header
+            have been stripped by :func:`parse_log`. Must begin with
+            ``CEF:0|Ubiquiti|``.
+
+    Returns:
+        Structured dict with ``log_type='firewall'`` and populated
+        network / rule / threat fields on a recognised threat event,
+        or ``None`` when the body is not a Ubiquiti threat-class CEF
+        line (foreign vendor, audit event, malformed header, etc.).
+        Callers should treat ``None`` as "fall back to
+        :func:`parse_system`" so ``raw_log`` is still persisted.
+    """
+    match = CEF_HEADER.match(body)
+    if not match:
+        return None
+
+    # Only claim Ubiquiti CEF; a relayed foreign-vendor CEF (rare but
+    # possible) has its own field schema we cannot interpret.
+    if match.group('vendor') != 'Ubiquiti':
+        return None
+
+    event_class_id = match.group('event_class_id')
+    name = match.group('name')
+
+    # Threat-class CEF events only. UniFi uses ECID 2xx for IDS/IPS
+    # detections and the ``name`` field reliably begins with "Threat".
+    if not event_class_id.startswith('2') or not name.startswith('Threat'):
+        return None
+
+    ext = _parse_cef_extensions(match.group('extensions'))
+
+    # Routed into 'firewall' to share UIP's existing filter UI and
+    # Flow/Dashboard SQL with netfilter blocks. ``rule_desc='IDS/IPS''
+    # (set below from UNIFIpolicyType) is what distinguishes them.
+    result: dict = {'log_type': 'firewall'}
+
+    # ── Network 5-tuple ────────────────────────────────────────────────
+    if ext.get('src'):
+        result['src_ip'] = ext['src']
+    if ext.get('dst'):
+        result['dst_ip'] = ext['dst']
+
+    for ext_key, result_key in (('spt', 'src_port'), ('dpt', 'dst_port')):
+        raw = ext.get(ext_key)
+        if raw is None:
+            continue
+        try:
+            result[result_key] = int(raw)
+        except ValueError:
+            # Malformed port — leave unset; the raw_log is still saved.
+            pass
+
+    if ext.get('proto'):
+        result['protocol'] = ext['proto'].lower()
+
+    # Map destination port to its IANA service name, mirroring the
+    # firewall parser so the dataflow view shows the same labels
+    # regardless of which parser produced the row.
+    result['service_name'] = get_service_name(
+        result.get('dst_port'), result.get('protocol')
+    )
+
+    # ── Action ─────────────────────────────────────────────────────────
+    action_raw = ext.get('act')
+    if action_raw == 'blocked':
+        result['rule_action'] = 'block'
+    elif action_raw == 'allowed':
+        result['rule_action'] = 'allow'
+
+    # ── Rule / policy metadata ─────────────────────────────────────────
+    if ext.get('UNIFIpolicyName'):
+        result['rule_name'] = ext['UNIFIpolicyName']
+    if ext.get('UNIFIpolicyType'):
+        result['rule_desc'] = ext['UNIFIpolicyType']
+
+    # ── Direction ──────────────────────────────────────────────────────
+    direction_raw = ext.get('UNIFIdirection', '').lower()
+    if direction_raw in _UNIFI_DIRECTION:
+        result['direction'] = _UNIFI_DIRECTION[direction_raw]
+
+    # ── Geo country (external party's region) ──────────────────────────
+    src_region = ext.get('UNIFIsrcRegion')
+    dst_region = ext.get('UNIFIdstRegion')
+    if direction_raw == 'incoming' and src_region:
+        result['geo_country'] = src_region.upper()
+    elif direction_raw == 'outgoing' and dst_region:
+        result['geo_country'] = dst_region.upper()
+    elif src_region and not dst_region:
+        result['geo_country'] = src_region.upper()
+    elif dst_region and not src_region:
+        result['geo_country'] = dst_region.upper()
+
+    # ── Threat score (qualitative → 0-100 integer) ─────────────────────
+    risk = ext.get('UNIFIrisk', '').lower()
+    if risk in _UNIFI_RISK_SCORE:
+        result['threat_score'] = _UNIFI_RISK_SCORE[risk]
+
+    # ── Threat categories ──────────────────────────────────────────────
+    # The Suricata signature description (e.g. "ET DROP Dshield Block
+    # Listed Source group 1") is the most actionable label for filtering
+    # and alerting; expose it via the existing ``threat_categories`` array.
+    signature = ext.get('UNIFIipsSignature')
+    if signature:
+        result['threat_categories'] = [signature]
+
+    # ── Device MAC (the UDM emitting the event) ────────────────────────
+    if ext.get('UNIFIdeviceMac'):
+        result['mac_address'] = ext['UNIFIdeviceMac']
+
+    return result
+
+
 def parse_system(body: str) -> dict:
     """Parse a system log line. Stores raw log only."""
     return {'log_type': 'system'}
 
 
 def detect_log_type(body: str) -> str:
-    """Detect log type from the syslog message body."""
+    """Detect log type from the syslog message body.
+
+    Returns one of the values listed in the module docstring. Order of
+    checks matters: more specific formats (CEF, iptables) are tried
+    before the daemon-name heuristics, which in turn run before the
+    ``system`` catch-all.
+
+    Non-threat CEF events (audit, device, wifi, client, vpn) are not
+    routed to a dedicated type here; they fall through to ``system`` so
+    pre-existing storage behaviour is preserved.
+
+    Note: CEF threat events are returned as ``'firewall'`` (not a new
+    log_type). They are firewall block decisions from a user perspective
+    — they belong in the same UI bucket as netfilter blocks. The
+    ``rule_desc='IDS/IPS'`` column distinguishes them from netfilter
+    blocks for callers that care. ``parse_log`` disambiguates which
+    sub-parser to invoke by inspecting the body.
+    """
+    # CEF: UniFi Network 10.x "SIEM Server" Activity Logging — threat
+    # subset only (ECID 2xx). The cheap ``startswith`` short-circuits
+    # before the regex match for the >99% of lines that are not CEF.
+    if body.startswith('CEF:0|Ubiquiti|') and CEF_THREAT_PREMATCH.match(body):
+        return 'firewall'
+
     # Firewall: contains iptables-style fields
     if 'SRC=' in body and 'DST=' in body and 'PROTO=' in body:
         return 'firewall'
@@ -508,7 +810,20 @@ def parse_log(raw_log: str) -> dict | None:
     log_type = detect_log_type(body)
 
     if log_type == 'firewall':
-        parsed = parse_firewall(body)
+        # Two sub-formats live under ``firewall``: classic netfilter
+        # kernel logs and CEF-formatted IDS/IPS threat events from
+        # Network 10.x SIEM Server forwarding. Disambiguate by body
+        # shape. ``parse_cef_threat`` returns ``None`` if the full
+        # header turns out not to match the expected shape after the
+        # cheap pre-match in ``detect_log_type``; fall back to
+        # ``parse_system`` so the raw line is still stored and never
+        # silently dropped.
+        if body.startswith('CEF:0|Ubiquiti|'):
+            parsed = parse_cef_threat(body)
+            if parsed is None:
+                parsed = parse_system(body)
+        else:
+            parsed = parse_firewall(body)
     elif log_type == 'dns':
         parsed = parse_dns(body)
     elif log_type == 'dhcp':

--- a/receiver/parsers.py
+++ b/receiver/parsers.py
@@ -82,6 +82,34 @@ DHCP_DISC    = re.compile(rf'DHCPDISCOVER\((\S+)\)\s+(?:([0-9a-fA-F:.]+)\s+)?({M
 DHCP_OFFER   = re.compile(rf'DHCPOFFER\((\S+)\)\s+([0-9a-fA-F:.]+)\s+({MAC_PATTERN})')
 DHCP_REQ     = re.compile(rf'DHCPREQUEST\((\S+)\)\s+([0-9a-fA-F:.]+)\s+({MAC_PATTERN})')
 
+
+def _valid_ip_or_none(value) -> str | None:
+    """Return an IP string only when PostgreSQL ``INET`` can accept it.
+
+    Live ingestion already validates parsed ``src_ip`` / ``dst_ip`` just
+    before insert, but some backfills call narrow parsers directly and then
+    update ``INET`` columns. Keeping this small helper near the shared regexes
+    lets both paths apply the same DB-boundary guard.
+    """
+    if not value:
+        return None
+    try:
+        ipaddress.ip_address(value)
+    except (ValueError, TypeError):
+        return None
+    return value
+
+
+def _valid_mac_or_none(value) -> str | None:
+    """Return a MAC string only when PostgreSQL ``MACADDR`` can accept it.
+
+    Invalid MACs are left unset rather than allowed to fail an entire batch
+    insert or historical backfill update.
+    """
+    if isinstance(value, str) and MAC_RE.fullmatch(value):
+        return value
+    return None
+
 # ── WiFi (stamgr / hostapd) ───────────────────────────────────────────────────
 WIFI_EVENT  = re.compile(r'(\w+):\s+STA\s+([0-9a-f:]+)')
 WIFI_ASSOC  = re.compile(r'STA\s+([0-9a-f:]+)\s+.*?(associated|disassociated|deauthenticated|authenticated)')
@@ -659,10 +687,10 @@ def parse_cef_threat(body: str) -> dict | None:
     result: dict = {'log_type': 'firewall'}
 
     # ── Network 5-tuple ────────────────────────────────────────────────
-    if ext.get('src'):
-        result['src_ip'] = ext['src']
-    if ext.get('dst'):
-        result['dst_ip'] = ext['dst']
+    for ext_key, result_key in (('src', 'src_ip'), ('dst', 'dst_ip')):
+        ip_value = _valid_ip_or_none(ext.get(ext_key))
+        if ip_value:
+            result[result_key] = ip_value
 
     for ext_key, result_key in (('spt', 'src_port'), ('dpt', 'dst_port')):
         raw = ext.get(ext_key)
@@ -728,8 +756,9 @@ def parse_cef_threat(body: str) -> dict | None:
         result['threat_categories'] = [signature]
 
     # ── Device MAC (the UDM emitting the event) ────────────────────────
-    if ext.get('UNIFIdeviceMac'):
-        result['mac_address'] = ext['UNIFIdeviceMac']
+    mac_address = _valid_mac_or_none(ext.get('UNIFIdeviceMac'))
+    if mac_address:
+        result['mac_address'] = mac_address
 
     return result
 
@@ -841,16 +870,13 @@ def parse_log(raw_log: str) -> dict | None:
     # Validate IP fields — reject invalid inet values before DB insert
     for ip_field in ('src_ip', 'dst_ip'):
         ip_val = parsed.get(ip_field)
-        if ip_val:
-            try:
-                ipaddress.ip_address(ip_val)
-            except ValueError:
-                logger.warning("Invalid %s '%s' in log: %.300s", ip_field, ip_val, original_raw)
-                parsed[ip_field] = None
+        if ip_val and not _valid_ip_or_none(ip_val):
+            logger.warning("Invalid %s '%s' in log: %.300s", ip_field, ip_val, original_raw)
+            parsed[ip_field] = None
 
     # Validate MAC field — reject invalid macaddr values before DB insert
     mac_val = parsed.get('mac_address')
-    if mac_val and not MAC_RE.fullmatch(mac_val):
+    if mac_val and not _valid_mac_or_none(mac_val):
         logger.warning("Invalid mac_address '%s' in log: %.300s", mac_val, original_raw)
         parsed['mac_address'] = None
 

--- a/receiver/tests/test_backfill_cef.py
+++ b/receiver/tests/test_backfill_cef.py
@@ -1,0 +1,229 @@
+"""Tests for the one-shot CEF parser backfill in ``backfill.py``.
+
+Mirrors the in-process style used by the other backfill tests (see
+``TestBackfillRdnsToggle`` in ``test_enrichment.py``): we mock ``db``
+at the Database-method boundary rather than the cursor level, so the
+tests assert *behaviour* (which batch was requested, which updates
+were applied) rather than coupling to SQL text.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from backfill import BackfillTask
+
+
+# Real-world CEF threat as it would be stored in ``raw_log``:
+# a full RFC3164 syslog line containing a Network 10.x SIEM-Server
+# CEF threat event (DShield Block List, ECID 201, ``incoming``).
+SAMPLE_CEF_RAW = (
+    'May 14 13:51:35 UDMPRO '
+    'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|'
+    'src=176.65.148.67 dst=192.168.200.56 proto=UDP spt=123 dpt=64280 '
+    'act=blocked UNIFIrisk=medium UNIFIpolicyName=DShield Block List '
+    'UNIFIpolicyType=IDS/IPS UNIFIdirection=incoming UNIFIsrcRegion=NL '
+    'UNIFIipsSignature=ET DROP Dshield Block Listed Source group 1'
+)
+
+
+@pytest.fixture
+def task():
+    """Build a ``BackfillTask`` with all DB methods mocked.
+
+    Tests configure ``cef_parser_backfill_batch.return_value`` per case
+    and inspect what was passed to ``patch_cef_parsed_logs``.
+    """
+    db = MagicMock()
+    enricher = MagicMock()
+    enricher.abuseipdb.enabled = False
+    enricher.enrich.side_effect = lambda parsed, **_kwargs: parsed
+    return BackfillTask(db=db, enricher=enricher)
+
+
+@pytest.fixture
+def config_store(monkeypatch):
+    """Replace ``db.get_config`` / ``db.set_config`` with an in-memory dict.
+
+    Returns the dict so tests can pre-seed gate flags and assert that
+    the backfill writes the cursor and done-flag correctly.
+    """
+    import db as db_module
+    store: dict = {}
+
+    def fake_get(_db, key, default=None):
+        return store.get(key, default)
+
+    def fake_set(_db, key, value):
+        store[key] = value
+
+    monkeypatch.setattr(db_module, 'get_config', fake_get, raising=False)
+    monkeypatch.setattr(db_module, 'set_config', fake_set, raising=False)
+    return store
+
+
+class TestBackfillCefParser:
+    """Functional tests for ``BackfillTask._backfill_cef_parser``."""
+
+    def test_gate_when_done_returns_early(self, task, config_store):
+        """Once ``cef_parser_backfill_done=True``, the backfill no-ops.
+
+        This is the idempotency contract: a deploy of UIP after the
+        backfill completed must not re-scan the entire ``logs`` table.
+        """
+        config_store['cef_parser_backfill_done'] = True
+
+        task._backfill_cef_parser()
+
+        task.db.cef_parser_backfill_batch.assert_not_called()
+        task.db.patch_cef_parsed_logs.assert_not_called()
+
+    def test_empty_batch_marks_done(self, task, config_store):
+        """When the DB returns no candidate rows, the done flag is set so
+        subsequent cycles short-circuit on the gate above."""
+        task.db.cef_parser_backfill_batch.return_value = []
+
+        task._backfill_cef_parser()
+
+        assert config_store.get('cef_parser_backfill_done') is True
+        # No updates attempted on an empty batch.
+        task.db.patch_cef_parsed_logs.assert_not_called()
+
+    def test_parses_and_patches_real_threat(self, task, config_store):
+        """Happy path: a real CEF threat row is parsed, enriched, and
+        submitted to ``patch_cef_parsed_logs`` with all expected
+        structural fields. ``enricher.enrich`` is called in local-only mode
+        so geo / ASN / rDNS / remote_ip populate without synchronous
+        AbuseIPDB API calls — without this, Threat Map (which filters on
+        ``geo_lat IS NOT NULL``) would miss the backfilled rows."""
+        task.db.cef_parser_backfill_batch.return_value = [(42, SAMPLE_CEF_RAW)]
+        task.db.patch_cef_parsed_logs.return_value = 1
+
+        task._backfill_cef_parser()
+
+        # The DB was asked for the next batch starting after id=0.
+        task.db.cef_parser_backfill_batch.assert_called_once()
+        called_last_id = task.db.cef_parser_backfill_batch.call_args[0][0]
+        assert called_last_id == 0
+
+        # Each parsed row was run through local enrichment (geo_*, asn_*,
+        # rdns, remote_ip) without synchronous AbuseIPDB lookups. Without
+        # this call, historical CEF rows never appear on the Threat Map.
+        task.enricher.enrich.assert_called_once()
+        assert task.enricher.enrich.call_args.kwargs == {'include_threat': False}
+
+        # Exactly one update submitted, for row 42, with the expected fields.
+        task.db.patch_cef_parsed_logs.assert_called_once()
+        (updates,), _ = task.db.patch_cef_parsed_logs.call_args
+        assert len(updates) == 1
+        row_id, parsed = updates[0]
+        assert row_id == 42
+        assert parsed['log_type'] == 'firewall'
+        assert parsed['src_ip'] == '176.65.148.67'
+        assert parsed['dst_ip'] == '192.168.200.56'
+        assert parsed['rule_action'] == 'block'
+        assert parsed['geo_country'] == 'NL'
+        assert parsed['threat_score'] == 60  # medium → 60
+
+        # Cursor advanced to the highest id processed.
+        assert config_store.get('cef_parser_backfill_last_id') == 42
+        # Not yet marked done — there might be more on the next cycle.
+        assert config_store.get('cef_parser_backfill_done') is None
+
+    def test_enriched_remote_ip_is_enqueued_for_deferred_abuseipdb(self, task, config_store):
+        """CEF backfill must not perform synchronous AbuseIPDB lookups, but it
+        should still feed the normal deferred queue once local enrichment has
+        identified the remote IP."""
+        task.enricher.abuseipdb.enabled = True
+        task.db.cef_parser_backfill_batch.return_value = [(42, SAMPLE_CEF_RAW)]
+        task.db.patch_cef_parsed_logs.return_value = 1
+
+        def fake_enrich(parsed, *, include_threat=True):
+            assert include_threat is False
+            parsed['remote_ip'] = parsed['src_ip']
+            parsed['geo_lat'] = 52.3676
+            parsed['geo_lon'] = 4.9041
+            return parsed
+
+        task.enricher.enrich.side_effect = fake_enrich
+
+        task._backfill_cef_parser()
+
+        task.db.enqueue_threat_backfill.assert_called_once_with(
+            '176.65.148.67',
+            source='cef_backfill',
+        )
+        (updates,), _ = task.db.patch_cef_parsed_logs.call_args
+        assert updates[0][1]['remote_ip'] == '176.65.148.67'
+        assert updates[0][1]['geo_lat'] == 52.3676
+
+    def test_cursor_resumes_from_persisted_last_id(self, task, config_store):
+        """An interrupted backfill resumes from the persisted cursor
+        rather than re-scanning from id=0."""
+        config_store['cef_parser_backfill_last_id'] = 1000
+        task.db.cef_parser_backfill_batch.return_value = []
+
+        task._backfill_cef_parser()
+
+        # The query was issued with last_id=1000, not 0.
+        called_last_id = task.db.cef_parser_backfill_batch.call_args[0][0]
+        assert called_last_id == 1000
+
+    def test_non_threat_row_is_skipped(self, task, config_store):
+        """Defensive: if a row passes the SQL regex pre-filter but
+        ``parse_cef_threat`` returns ``None`` (e.g. malformed extensions or
+        foreign-vendor CEF that slipped through), it is silently
+        skipped and not included in the update batch."""
+        # An audit CEF event masquerading at an unexpected position —
+        # ``parse_cef_threat`` will reject it (ECID 5xx, not threat-class).
+        non_threat = (
+            'May 14 00:59:56 UDMPRO '
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|546|Config Modified|5|'
+            'UNIFIcategory=Audit src=192.168.200.144'
+        )
+        task.db.cef_parser_backfill_batch.return_value = [
+            (10, SAMPLE_CEF_RAW),
+            (11, non_threat),
+        ]
+
+        task._backfill_cef_parser()
+
+        # Only the real threat made it into the update batch.
+        (updates,), _ = task.db.patch_cef_parsed_logs.call_args
+        assert len(updates) == 1
+        assert updates[0][0] == 10
+
+        # Cursor still advances past *both* rows so they don't come back
+        # on the next cycle — they've been examined and rejected.
+        assert config_store.get('cef_parser_backfill_last_id') == 11
+
+    def test_missing_cef_marker_in_raw_log_is_skipped(self, task, config_store):
+        """Truly pathological: ``raw_log`` matched the regex (perhaps via
+        a future Postgres bug or a copy-paste in the column) but doesn't
+        actually contain ``CEF:0|Ubiquiti|``. The parser must not crash."""
+        task.db.cef_parser_backfill_batch.return_value = [
+            (1, 'May 14 13:00:00 UDMPRO syslog: not actually a CEF line'),
+        ]
+
+        task._backfill_cef_parser()
+
+        # No updates submitted, cursor still advances.
+        task.db.patch_cef_parsed_logs.assert_not_called()
+        assert config_store.get('cef_parser_backfill_last_id') == 1
+
+    def test_full_batch_does_not_mark_done(self, task, config_store):
+        """If the batch is full (size N), there may be more rows pending
+        — done flag must NOT be set yet, the cursor advances for the
+        next cycle to pick up where this one left off."""
+        from backfill import CEF_PARSER_BATCH_SIZE
+
+        # Build N+ rows so the batch comes back at max size.
+        rows = [(i, SAMPLE_CEF_RAW) for i in range(1, CEF_PARSER_BATCH_SIZE + 1)]
+        task.db.cef_parser_backfill_batch.return_value = rows
+        task.db.patch_cef_parsed_logs.return_value = CEF_PARSER_BATCH_SIZE
+
+        task._backfill_cef_parser()
+
+        # Cursor at the last row, but NOT done.
+        assert config_store.get('cef_parser_backfill_last_id') == CEF_PARSER_BATCH_SIZE
+        assert config_store.get('cef_parser_backfill_done') is None

--- a/receiver/tests/test_enrichment.py
+++ b/receiver/tests/test_enrichment.py
@@ -13,6 +13,7 @@ from enrichment import (
     GeoIPEnricher,
     RDNSEnricher,
     TTLCache,
+    _merge_threat_data,
     _parse_bool_setting,
     _resolve_rdns_enabled,
     is_public_ip,
@@ -799,6 +800,106 @@ class TestRDNSEnricherConcurrency:
             assert r == {'rdns': 'host-1.2.3.4.example.com'}
 
 
+# ── _merge_threat_data ───────────────────────────────────────────────────────
+
+class TestMergeThreatData:
+    """Tests for the helper that merges enricher threat data into a
+    parsed log dict without clobbering parser-set values.
+
+    Background: ``parse_cef_threat`` sets ``threat_score`` (from
+    ``UNIFIrisk``) and ``threat_categories`` (from ``UNIFIipsSignature``)
+    for CEF threat events that route through the firewall log_type.
+    The subsequent AbuseIPDB enrichment runs on the same row; without
+    this merge, ``parsed.update(threat_data)`` would silently overwrite
+    those parser-set values with AbuseIPDB's (potentially 0) score for
+    IPs not in their database.
+    """
+
+    def test_max_score_preserves_parser_value_when_abuseipdb_returns_zero(self):
+        """A medium UniFi event (score=60) must not be downgraded to 0
+        by an AbuseIPDB cache miss."""
+        parsed = {'threat_score': 60, 'threat_categories': ['UniFi sig']}
+        threat_data = {'threat_score': 0, 'threat_categories': []}
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_score'] == 60
+
+    def test_max_score_takes_higher_abuseipdb_value(self):
+        """An AbuseIPDB score that exceeds the parser-set value wins —
+        the higher reading is more alarming and is what callers want."""
+        parsed = {'threat_score': 60}
+        threat_data = {'threat_score': 95}
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_score'] == 95
+
+    def test_score_set_when_parser_left_it_none(self):
+        """When the parser left ``threat_score`` unset (no
+        ``UNIFIrisk``, classic netfilter row, etc.), the AbuseIPDB
+        value is used as-is — including 0, which is the established
+        signal for "looked up, not abusive"."""
+        parsed = {}
+        threat_data = {'threat_score': 0}
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_score'] == 0
+
+    def test_categories_union_preserves_both_sources(self):
+        """UniFi IPS signature and AbuseIPDB categories coexist; order
+        is preserved (UniFi first since it's already in ``parsed``)
+        and duplicates are dropped."""
+        parsed = {'threat_categories': ['ET DROP Dshield Block Listed Source group 1']}
+        threat_data = {
+            'threat_categories': ['blacklist', 'scanner'],
+        }
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_categories'] == [
+            'ET DROP Dshield Block Listed Source group 1',
+            'blacklist',
+            'scanner',
+        ]
+
+    def test_categories_no_duplicates_after_merge(self):
+        parsed = {'threat_categories': ['blacklist']}
+        threat_data = {'threat_categories': ['blacklist', 'scanner']}
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_categories'] == ['blacklist', 'scanner']
+
+    def test_other_threat_fields_use_standard_update(self):
+        """AbuseIPDB-only fields (``abuse_*``) have no parser-set
+        counterpart and should update normally."""
+        parsed = {'threat_score': 60}
+        threat_data = {
+            'threat_score': 0,
+            'abuse_total_reports': 42,
+            'abuse_is_tor': True,
+        }
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert parsed['threat_score'] == 60  # preserved
+        assert parsed['abuse_total_reports'] == 42
+        assert parsed['abuse_is_tor'] is True
+
+    def test_caller_dict_not_mutated(self):
+        """The merge helper must not mutate the caller's ``threat_data``
+        dict — callers may reuse it for logging or coalescing checks."""
+        parsed = {'threat_score': 60, 'threat_categories': ['UniFi']}
+        threat_data = {'threat_score': 30, 'threat_categories': ['AIPDB']}
+        original = dict(threat_data)
+
+        _merge_threat_data(parsed, threat_data)
+
+        assert threat_data == original
+
+
 # ── Enricher toggle gates (live + reload) ────────────────────────────────────
 
 class TestEnricherRdnsToggle:
@@ -825,6 +926,34 @@ class TestEnricherRdnsToggle:
         e.enrich(parsed)
         e.rdns.lookup.assert_not_called()
         assert 'rdns' not in parsed
+
+    def test_include_threat_false_keeps_local_enrichment_only(self, monkeypatch):
+        """Historical parser backfills need GeoIP/ASN/rDNS/remote_ip without
+        spending AbuseIPDB quota synchronously. ``include_threat=False`` keeps
+        that path local-only; the caller can enqueue the remote IP separately."""
+        e = self._make_enricher(monkeypatch, db=None)
+        e.geoip.lookup = MagicMock(return_value={
+            'geo_country': 'NL',
+            'geo_lat': 52.3676,
+            'geo_lon': 4.9041,
+        })
+        e.rdns.lookup = MagicMock(return_value={'rdns': 'example.test'})
+        e.abuseipdb.lookup = MagicMock(return_value={'threat_score': 95})
+
+        parsed = {
+            'log_type': 'firewall',
+            'src_ip': '8.8.8.8',
+            'dst_ip': '192.168.1.5',
+            'rule_action': 'block',
+        }
+
+        e.enrich(parsed, include_threat=False)
+
+        assert parsed['remote_ip'] == '8.8.8.8'
+        assert parsed['geo_country'] == 'NL'
+        assert parsed['rdns'] == 'example.test'
+        assert 'threat_score' not in parsed
+        e.abuseipdb.lookup.assert_not_called()
 
     def test_disabled_via_system_config_skips_lookup(self, monkeypatch):
         # env unset by conftest

--- a/receiver/tests/test_parsers.py
+++ b/receiver/tests/test_parsers.py
@@ -628,6 +628,31 @@ class TestParseCefThreat:
         assert r.get('src_port') is None
         assert r.get('dst_port') is None
 
+    def test_invalid_ip_fields_are_not_returned(self):
+        """Direct parser callers (notably historical backfill) bypass
+        ``parse_log``'s final DB-boundary validation, so CEF IP fields must
+        be checked before they can reach PostgreSQL ``INET`` columns."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=not-an-ip dst=192.168.200.56'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r.get('src_ip') is None
+        assert r['dst_ip'] == '192.168.200.56'
+
+    def test_invalid_device_mac_is_not_returned(self):
+        """Malformed ``UNIFIdeviceMac`` values are left unset so CEF
+        backfill updates cannot fail the whole batch on PostgreSQL
+        ``MACADDR`` coercion."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIdeviceMac=not-a-mac'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r.get('mac_address') is None
+
     def test_direction_unknown_value_left_unset(self):
         """An ``UNIFIdirection`` value outside the known mapping leaves
         ``direction`` unset rather than passing through a garbage value."""

--- a/receiver/tests/test_parsers.py
+++ b/receiver/tests/test_parsers.py
@@ -14,6 +14,7 @@ from parsers import (
     detect_log_type,
     extract_mac,
     match_vpn_ip,
+    parse_cef_threat,
     parse_dhcp,
     parse_dns,
     parse_firewall,
@@ -152,6 +153,42 @@ class TestDetectLogType:
 
     def test_system_earlyoom(self):
         body = 'earlyoom[456]: mem avail 1234 MiB'
+        assert detect_log_type(body) == 'system'
+
+    def test_cef_threat_routes_to_firewall(self):
+        """Network 10.x SIEM Server CEF threat events share the
+        ``firewall`` log_type with netfilter blocks.
+
+        These are firewall block decisions from a user perspective and
+        share UIP's existing FIREWALL/BLOCK filter UI; the
+        ``rule_desc='IDS/IPS'`` column distinguishes them downstream.
+        """
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|'
+            'UNIFIcategory=Security src=1.2.3.4'
+        )
+        assert detect_log_type(body) == 'firewall'
+
+    def test_cef_audit_falls_through_to_system(self):
+        """Non-threat CEF (audit / config / admin) is intentionally left to
+        ``parse_system`` until dedicated routing is added in a future change.
+
+        This preserves current behaviour for audit events that previously
+        landed in ``system`` — no silent regression for existing users.
+        """
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|546|Config Modified|5|'
+            'UNIFIcategory=Audit'
+        )
+        assert detect_log_type(body) == 'system'
+
+    def test_cef_non_ubiquiti_falls_through(self):
+        """Foreign-vendor CEF (theoretically possible with rsyslog relays)
+        must not be hijacked by this parser. We only claim Ubiquiti CEF."""
+        body = (
+            'CEF:0|Fortinet|FortiGate|7.4.0|201|Some Event|7|'
+            'src=1.2.3.4'
+        )
         assert detect_log_type(body) == 'system'
 
 
@@ -321,6 +358,321 @@ class TestParseWifi:
         body = 'stahtd[1234]: {not valid json}'
         r = parse_wifi(body)
         assert r['wifi_event'] == 'stahtd'
+
+
+# ── parse_cef_threat ─────────────────────────────────────────────────────────
+
+class TestParseCefThreat:
+    """Tests for the CEF threat-class event parser.
+
+    Sample events here are abridged but field-faithful renderings of real
+    syslog messages received from a UDM Pro running UniFi OS 5.0.16 /
+    Network 10.3.58 with *Settings → CyberSecure → Traffic Logging →
+    Activity Logging → SIEM Server* enabled. Threat events route to
+    ``log_type='firewall'`` so they share UIP's existing FIREWALL /
+    BLOCK filter UI with netfilter blocks; ``rule_desc='IDS/IPS'``
+    distinguishes them downstream.
+    """
+
+    # Real-world incoming-threat event: DShield Block List rule on the
+    # IDS/IPS policy, captured 2026-05-14. Blocked NTP query from a
+    # known-bad NL host to an internal client.
+    INBOUND_THREAT = (
+        'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|'
+        'UNIFIcategory=Security UNIFIhost=UDMPRO proto=UDP spt=123 dpt=64280 '
+        'act=blocked app=Other UNIFIrisk=medium UNIFIpolicyName=DShield Block List '
+        'UNIFIpolicyType=IDS/IPS UNIFIdirection=incoming '
+        'deviceOutboundInterface=Default UNIFIdeviceMac=e0:63:da:5b:17:11 '
+        'UNIFIdeviceName=UDMPRO UNIFIdeviceModel=UDM-Pro UNIFIdeviceIp=192.168.200.1 '
+        'UNIFIdeviceVersion=5.0.16 src=176.65.148.67 dst=192.168.200.56 '
+        'UNIFIsrcRegion=NL UNIFIdstZone=Internal UNIFIdstDomain=pool.ntp.org '
+        'UNIFIipsSignature=ET DROP Dshield Block Listed Source group 1 '
+        'UNIFIipsSignatureId=2402000 UNIFIutcTime=2026-05-14T11:51:35.761Z '
+        'msg=A network intrusion attempt from 176.65.148.67 to 192.168.200.56 '
+        'has been detected and blocked.'
+    )
+
+    # Real-world outgoing-block: an internal client trying BitTorrent DHT
+    # ping, blocked by the P2P IDS policy. Same event class (201) but
+    # opposite direction — exercises the inverted geo-country mapping.
+    OUTBOUND_P2P = (
+        'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|9|'
+        'UNIFIcategory=Security proto=UDP spt=27032 dpt=6881 act=blocked '
+        'app=Other UNIFIrisk=high UNIFIpolicyName=P2P UNIFIpolicyType=IDS/IPS '
+        'UNIFIdirection=outgoing src=192.168.200.175 dst=46.107.202.150 '
+        'UNIFIsrcZone=Internal UNIFIdstRegion=HU '
+        'UNIFIipsSignature=ET P2P BitTorrent DHT ping request '
+        'UNIFIipsSignatureId=2008581 UNIFIutcTime=2026-05-14T10:44:34.387Z '
+        'msg=A network intrusion attempt from 192.168.200.175 to 46.107.202.150 '
+        'has been detected and blocked.'
+    )
+
+    # Audit event — same CEF envelope, different event class (5xx range)
+    # and category. Should NOT be claimed by parse_cef; parse_log routes
+    # it to parse_system instead.
+    CONFIG_AUDIT = (
+        'CEF:0|Ubiquiti|UniFi Network|10.3.58|546|Config Modified|5|'
+        'UNIFIcategory=Audit UNIFIhost=UDMPRO src=192.168.200.159 '
+        'UNIFIutcTime=2026-05-13T22:59:56.816Z msg=Config change.'
+    )
+
+    def test_inbound_threat_full_fields(self):
+        """All structured fields populated from a real DShield-block event."""
+        r = parse_cef_threat(self.INBOUND_THREAT)
+        assert r is not None
+        assert r['log_type'] == 'firewall'
+        assert r['src_ip'] == '176.65.148.67'
+        assert r['dst_ip'] == '192.168.200.56'
+        assert r['src_port'] == 123
+        assert r['dst_port'] == 64280
+        assert r['protocol'] == 'udp'
+        assert r['rule_action'] == 'block'
+        assert r['rule_name'] == 'DShield Block List'
+        assert r['rule_desc'] == 'IDS/IPS'
+        assert r['direction'] == 'inbound'
+        assert r['geo_country'] == 'NL'
+        assert r['threat_score'] == 60  # medium → 60 (clears Threats counter)
+        assert r['threat_categories'] == ['ET DROP Dshield Block Listed Source group 1']
+
+    def test_outbound_p2p_inverts_geo_to_dst_region(self):
+        """For outbound flows the external party is the destination, so
+        ``UNIFIdstRegion`` (not ``UNIFIsrcRegion``) is the interesting geo."""
+        r = parse_cef_threat(self.OUTBOUND_P2P)
+        assert r is not None
+        assert r['src_ip'] == '192.168.200.175'
+        assert r['dst_ip'] == '46.107.202.150'
+        assert r['direction'] == 'outbound'
+        assert r['geo_country'] == 'HU'
+        assert r['threat_score'] == 80  # high → 80
+        assert r['rule_name'] == 'P2P'
+
+    def test_audit_event_returns_none(self):
+        """Audit / non-threat CEF events are out of scope for this parser."""
+        assert parse_cef_threat(self.CONFIG_AUDIT) is None
+
+    def test_foreign_vendor_returns_none(self):
+        """CEF from non-Ubiquiti devices (e.g. a relayed Fortinet feed) is
+        not claimed — we have no field map for foreign vendors."""
+        body = (
+            'CEF:0|Fortinet|FortiGate|7.4.0|201|IPS Detection|7|'
+            'src=1.2.3.4 dst=10.0.0.1 act=blocked'
+        )
+        assert parse_cef_threat(body) is None
+
+    def test_malformed_header_returns_none(self):
+        """A truncated or otherwise unparseable CEF header is rejected
+        cleanly — must not raise."""
+        assert parse_cef_threat('CEF:0|Ubiquiti|truncated') is None
+
+    def test_non_cef_body_returns_none(self):
+        """Lines that don't begin with the CEF marker are out of scope."""
+        assert parse_cef_threat('Feb 8 16:43:49 UDR kernel: ordinary syslog line') is None
+
+    def test_protocol_normalised_to_lowercase(self):
+        """Match the firewall parser's convention: protocol is lowercase."""
+        r = parse_cef_threat(self.INBOUND_THREAT)
+        assert r['protocol'] == 'udp'
+
+    def test_act_allowed_maps_to_allow(self):
+        """``act=allowed`` (rare for the threat event class but possible)
+        maps to the existing ``rule_action='allow'`` schema value."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'act=allowed src=1.2.3.4 dst=2.3.4.5'
+        )
+        r = parse_cef_threat(body)
+        assert r['rule_action'] == 'allow'
+
+    def test_unknown_risk_yields_no_score(self):
+        """Risk levels not in the known mapping leave ``threat_score``
+        unset rather than guess a value."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIrisk=unknown'
+        )
+        r = parse_cef_threat(body)
+        assert r.get('threat_score') is None
+
+    def test_low_risk_maps_to_score(self):
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIrisk=low'
+        )
+        assert parse_cef_threat(body)['threat_score'] == 20
+
+    def test_medium_risk_clears_threats_counter_threshold(self):
+        """The UIP ``Threats`` stats counter is ``threat_score > 50``.
+        Mapping ``medium`` to 60 ensures verified threat-intel hits
+        (e.g. DShield Block List) show up there rather than only as
+        plain "blocked" entries."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIrisk=medium'
+        )
+        score = parse_cef_threat(body)['threat_score']
+        assert score == 60
+        assert score > 50  # The Threats-counter SQL filter
+
+    def test_high_risk_maps_to_score(self):
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIrisk=high'
+        )
+        assert parse_cef_threat(body)['threat_score'] == 80
+
+    def test_critical_risk_maps_to_score(self):
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIrisk=critical'
+        )
+        assert parse_cef_threat(body)['threat_score'] == 95
+
+    def test_service_name_derived_from_dst_port(self):
+        """``service_name`` is set from dst_port + protocol so the
+        Dataflow view labels CEF rows the same way as iptables rows
+        (e.g. UDP/123 → NTP, UDP/53 → DNS)."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 proto=UDP dpt=123'
+        )
+        r = parse_cef_threat(body)
+        assert r['service_name'] is not None
+        # Don't assert exact value — depends on services.py mapping;
+        # just confirm derivation fires when port+proto are present.
+
+    def test_missing_optional_fields_yields_none_values(self):
+        """A minimal threat event with only required header + a couple of
+        fields parses without raising; missing fields read as ``None``."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r['log_type'] == 'firewall'
+        assert r['src_ip'] == '1.2.3.4'
+        assert r['dst_ip'] == '2.3.4.5'
+        assert r.get('src_port') is None
+        assert r.get('dst_port') is None
+        assert r.get('threat_score') is None
+        assert r.get('rule_name') is None
+
+    def test_msg_field_preserves_spaces_and_punctuation(self):
+        """The ``msg=`` extension is special — its value runs to end-of-line
+        and contains arbitrary text. It must not be tokenised into key=value
+        fragments (a naive whitespace split would corrupt the message)."""
+        r = parse_cef_threat(self.INBOUND_THREAT)
+        # parse_cef does not currently surface msg as a top-level field, but
+        # parsing must not crash and surrounding fields must remain correct.
+        assert r['src_ip'] == '176.65.148.67'
+        assert r['threat_categories'] == ['ET DROP Dshield Block Listed Source group 1']
+
+    def test_extension_with_equals_in_value_is_handled(self):
+        """``msg=`` content can include ``=`` (e.g. shell-style ``a=b``)
+        without breaking the parser. Robustness against pathological inputs."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 msg=foo=bar baz=qux'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r['src_ip'] == '1.2.3.4'
+
+    def test_embedded_msg_marker_does_not_truncate_trailing_fields(self):
+        """Regression: an earlier extension value (e.g. a Suricata
+        signature description) may contain the literal substring
+        " msg=". Using ``rfind(' msg=')`` instead of ``find(' msg=')``
+        ensures the actual msg boundary (last in line, per UniFi's
+        emitter) wins and every field between the embedded " msg="
+        and end-of-line still parses.
+
+        Counterexample contributed during code review — preserved here
+        so future refactors of the extension parser cannot regress it.
+
+        Known limitation acknowledged: the inner key=value tokeniser
+        will still truncate ``UNIFIipsSignature`` at the embedded
+        ``msg=`` (it has no way to know it's inside a value, and CEF
+        doesn't escape ``=`` characters). In real UniFi output,
+        Suricata signature descriptions are descriptive English text
+        and don't contain ``key=`` patterns; this counterexample is
+        defensive. The rfind fix recovers the high-value fields
+        (``dst``, ``UNIFIrisk``, the real ``msg``) — full immunity
+        would require a known-key tokeniser, which is over-engineered
+        for the data UniFi actually emits.
+        """
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 UNIFIipsSignature=contains msg= text '
+            'dst=2.3.4.5 UNIFIrisk=high msg=real message at end'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        # Fields after the embedded " msg=" all parse correctly thanks
+        # to rfind picking the trailing msg= boundary.
+        assert r['src_ip'] == '1.2.3.4'
+        assert r['dst_ip'] == '2.3.4.5'         # would be missing without rfind
+        assert r['threat_score'] == 80          # high — would be unset without rfind
+        # Known limitation (see docstring): UNIFIipsSignature is
+        # truncated at the embedded ``msg=`` by the inner tokeniser.
+        assert r['threat_categories'] == ['contains']
+
+    def test_invalid_port_does_not_crash(self):
+        """A non-numeric port value (defensive: shouldn't happen with real
+        UniFi output, but the parser must not raise on malformed input)."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 spt=abc dpt=def'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r.get('src_port') is None
+        assert r.get('dst_port') is None
+
+    def test_direction_unknown_value_left_unset(self):
+        """An ``UNIFIdirection`` value outside the known mapping leaves
+        ``direction`` unset rather than passing through a garbage value."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIdirection=lateral'
+        )
+        r = parse_cef_threat(body)
+        assert r.get('direction') is None
+
+    def test_geo_fallback_src_region_when_direction_missing(self):
+        """When ``UNIFIdirection`` is absent and only ``UNIFIsrcRegion`` is
+        present, fall back to using the source region — better than no
+        geo data at all."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIsrcRegion=DE'
+        )
+        r = parse_cef_threat(body)
+        assert r['geo_country'] == 'DE'
+
+    def test_geo_fallback_dst_region_when_direction_missing(self):
+        """Symmetric fallback: only ``UNIFIdstRegion`` present, no
+        direction hint — use the destination region."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'src=1.2.3.4 dst=2.3.4.5 UNIFIdstRegion=FR'
+        )
+        r = parse_cef_threat(body)
+        assert r['geo_country'] == 'FR'
+
+    def test_msg_only_extension(self):
+        """When the extension portion contains *only* ``msg=...`` (no
+        other key=value pairs), the parser must not blow up — the rest
+        of the result is still well-formed albeit sparse."""
+        body = (
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected|7|'
+            'msg=A bare message with no other fields.'
+        )
+        r = parse_cef_threat(body)
+        assert r is not None
+        assert r['log_type'] == 'firewall'
+        # Nothing else should be set
+        assert r.get('src_ip') is None
+        assert r.get('rule_action') is None
 
 
 # ── derive_direction ─────────────────────────────────────────────────────────
@@ -547,3 +899,57 @@ class TestParseLog:
         line = 'Feb  8 16:43:49 UDR systemd[1]: Starting Daily Cleanup...'
         r = parse_log(line)
         assert r['log_type'] == 'system'
+
+    def test_cef_threat_end_to_end(self, monkeypatch):
+        """A real CEF threat line wrapped in the usual RFC3164 syslog
+        header is parsed into structured ``log_type='firewall'`` fields
+        so it shares the FIREWALL filter UI with netfilter blocks."""
+        monkeypatch.setenv('TZ', 'UTC')
+        line = (
+            'May 14 13:51:35 UDMPRO '
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|201|Threat Detected and Blocked|7|'
+            'src=176.65.148.67 dst=192.168.200.56 proto=UDP spt=123 dpt=64280 '
+            'act=blocked UNIFIrisk=medium UNIFIpolicyName=DShield Block List '
+            'UNIFIpolicyType=IDS/IPS UNIFIdirection=incoming UNIFIsrcRegion=NL'
+        )
+        r = parse_log(line)
+        assert r is not None
+        assert r['log_type'] == 'firewall'
+        assert r['src_ip'] == '176.65.148.67'
+        assert r['dst_ip'] == '192.168.200.56'
+        assert r['rule_action'] == 'block'
+        assert r['geo_country'] == 'NL'
+        assert r['protocol'] == 'udp'
+        assert r['raw_log'] == line  # Original raw preserved
+
+    def test_cef_audit_end_to_end_no_regression(self, monkeypatch):
+        """Audit / config-change CEF events still resolve to ``log_type='system'``
+        with ``raw_log`` preserved — no silent regression for existing data."""
+        monkeypatch.setenv('TZ', 'UTC')
+        line = (
+            'May 14 00:59:56 UDMPRO '
+            'CEF:0|Ubiquiti|UniFi Network|10.3.58|546|Config Modified|5|'
+            'UNIFIcategory=Audit UNIFIadmin=Operator src=192.168.200.159'
+        )
+        r = parse_log(line)
+        assert r is not None
+        assert r['log_type'] == 'system'
+        assert r['raw_log'] == line
+
+    def test_cef_unifi_os_doubled_timestamp_end_to_end(self, monkeypatch):
+        """UniFi OS-level CEF events sometimes carry a doubled timestamp
+        (RFC3164 *and* ISO8601), which pushes the hostname into the syslog
+        body and prefixes the ``CEF:`` marker. These are out-of-scope
+        audit-style events (ECID 11xx) — must not be claimed by the CEF
+        threat parser and must not crash; falling through to ``system``
+        with ``raw_log`` preserved is the correct behaviour."""
+        monkeypatch.setenv('TZ', 'UTC')
+        line = (
+            'May 15 00:41:02 2026-05-15T00:41:02.199Z UDMPRO '
+            'CEF:0|Ubiquiti|UniFi OS|5.0.16|1102|Application Updated|1|'
+            'UNIFIhost=Host UNIFIdeviceName=UDMPRO msg=Talk has been updated.'
+        )
+        r = parse_log(line)
+        assert r is not None
+        assert r['log_type'] == 'system'
+        assert r['raw_log'] == line


### PR DESCRIPTION
## Summary

Adds parsing for CEF-formatted IDS/IPS threat events emitted by UniFi Network 10.x's **Activity Logging -> SIEM Server** mode.

Threat events are routed into the existing `log_type='firewall'` bucket instead of introducing `log_type='ids'`, so they immediately participate in the existing FIREWALL filter, BLOCK action filter, Flow View, Dashboard counters, Top Threat IPs, and Threat Map behavior. `rule_desc='IDS/IPS'` is the discriminator for callers that need to distinguish CEF threat rows from classic netfilter rows.

## What Changed

- Added `parse_cef_threat()` for UniFi CEF threat-class events (`vendor=Ubiquiti`, ECID `2xx`, name starting with `Threat`).
- Added CEF detection/routing in `detect_log_type()` and CEF-vs-netfilter dispatch in `parse_log()`.
- Extracts the network tuple, action, policy metadata, direction, external country, UniFi risk score, IPS signature, and device MAC.
- Maps UniFi risk to UIP's existing `threat_score` scale:
  - `low -> 20`
  - `medium -> 60`
  - `high -> 80`
  - `critical -> 95`
- Adds a one-shot ID-cursor backfill for historical rows previously stored as `log_type='system'`.
- Backfill applies local enrichment only (`geo_*`, ASN, rDNS, `remote_ip`, device names), then queues remote IPs for the normal deferred AbuseIPDB worker. It does not spend AbuseIPDB quota synchronously during the historical scan.
- Adds `_merge_threat_data()` so live AbuseIPDB enrichment cannot clobber parser-derived UniFi scores/categories. Scores use `max(existing, incoming)` and categories are unioned.
- Fixes the CEF extension `msg=` splitter to use the final ` msg=` boundary, preserving trailing fields when an earlier value contains that literal substring.

## Why `firewall`, Not `ids`

CEF threat events are firewall block/allow decisions from a user perspective. Routing them to a separate `ids` log type would require new UI filters and duplicated dashboard/flow logic for little user value. Reusing `firewall` keeps the existing analytics path intact, while `rule_desc='IDS/IPS'` preserves the subtype.

## Backfill Behavior

The backfill is automatic and self-gated via:

- `cef_parser_backfill_done`
- `cef_parser_backfill_last_id`

It processes one `CEF_PARSER_BATCH_SIZE` batch per backfill cycle, advances the cursor past all examined rows, and marks done only once the DB returns an empty batch. Rows that match the SQL prefilter but fail the full parser are skipped with raw logs preserved.

## Tests

Ran the full receiver suite:

```bash
cd receiver
../.venv/bin/python -B -m pytest -p no:cacheprovider tests/ -q
```

Result:

```text
653 passed in 2.35s
```

## Follow-Ups Not In This PR

- Rename UI labels that still say `AbuseIPDB` for the mixed-source `threat_score` column.
- Add a real PostgreSQL integration test for the CEF backfill SQL if/when the project has a DB test harness.
- Add future parsers for non-threat CEF subcategories such as audit, wifi, device, and UniFi OS lifecycle events.
- Add README/docs mention for UniFi Network 10.x SIEM Server support.
